### PR TITLE
Pin plone.formwidget.recurrence = 1.2.3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -84,6 +84,7 @@ plone.app.widgets = 1.6.0
 plone.app.z3cform = 1.0
 plone.dexterity = 2.2.3
 z3c.form = 3.2.1
+plone.formwidget.recurrence = 1.2.3
 
 [sources]
 mosaiclayouts = git https://github.com/datakurre/mosaiclayouts egg=false


### PR DESCRIPTION
We need to pin plone.formwidget.recurrence to at least 1.2.3 to be compliant with plone.app.event 2.0a4.dev0 requirements (plone.formwidget.recurrence[z3cform]>=1.2.3)
