### PR TITLE
Port CSS refactoring from a Plone 4.3 feature branch into master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+RJS_CMD = node_modules/requirejs/bin/r.js
+LESS_CMD = node_modules/less/bin/lessc
+WATCH_CMD = node_modules/watch/cli.js
+
+STATIC = src/plone/app/mosaic/browser/static
+
+SOURCE_JS = $(shell find $(STATIC)/js -name "*.js")
+BUNDLE_JS = $(STATIC)/plone-mosaic.js
+SOURCE_LESS = $(STATIC)/css/mosaic.pattern.less
+BUNDLE_LESS = $(STATIC)/plone-mosaic.css
+
+# if mode variable is empty, setting debug build mode
+ifeq ($(mode),release)
+    RJS_ARGS = -o build.js generateSourceMaps=false preserveLicenseComments=true
+else
+    RJS_ARGS = -o build.js
+endif
+
+all: $(BUNDLE_JS) $(BUNDLE_LESS)
+
+$(BUNDLE_JS): $(SOURCE_JS)
+	$(RJS_CMD) $(RJS_ARGS)
+	cp $(BUNDLE_JS) $(BUNDLE_JS).tmp
+	grep -v sourceMapping $(BUNDLE_JS).tmp > $(BUNDLE_JS)
+	cat $(STATIC)/js/mosaic.pattern.js >> $(BUNDLE_JS)
+ifeq ($(mode),release)
+else
+	echo '' >> $(BUNDLE_JS)
+	grep sourceMapping $(BUNDLE_JS).tmp >> $(BUNDLE_JS)
+endif
+	rm $(BUNDLE_JS).tmp
+
+$(BUNDLE_LESS): $(SOURCE_LESS)
+	$(LESS_CMD) $(SOURCE_LESS) > $(BUNDLE_LESS)
+
+watch:
+	$(WATCH_CMD) make $(STATIC)
+
+clean:
+	rm -f $(BUNDLE_JS) $(BUNDLE_LESS)
+
+.PHONY: clean $(RJS_CMD)

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "plone-mosaic",
+  "version": "0.0.0",
+  "homepage": "https://github.com/plone/plone.app.mosaic",
+  "authors": [
+    "Asko Soukka <asko.soukka@iki.fi>"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "select2-bootstrap-css": "~1.4.6",
+    "bootstrap": "~3.3.4"
+  }
+}

--- a/src/plone/app/mosaic/browser/bbb/profiles/default/cssregistry.xml
+++ b/src/plone/app/mosaic/browser/bbb/profiles/default/cssregistry.xml
@@ -16,30 +16,7 @@
   <stylesheet id="++resource++plone.app.event/event.css"
               bundle="widgets" />
 
-  <stylesheet id="++resource++plone.app.mosaic/css/authoring.css"
-              title=""
-              bundle="mosaic"
-              applyPrefix="true"
-              media="screen"
-              rel="stylesheet"
-              rendering="import"
-              cacheable="True"
-              compression="safe"
-              cookable="True"
-              enabled="1"
-              expression=""/>
-
-  <stylesheet id="++resource++plone.app.mosaic/css/toolbar.css"
-              title=""
-              bundle="mosaic"
-              applyPrefix="true"
-              media="screen"
-              rel="stylesheet"
-              rendering="import"
-              cacheable="True"
-              compression="safe"
-              cookable="True"
-              enabled="1"
-              expression=""/>
+  <stylesheet id="++resource++plone.app.mosaic/plone-mosaic.css"
+              bundle="mosaic" />
 
 </object>

--- a/src/plone/app/mosaic/browser/static/css/authoring.css
+++ b/src/plone/app/mosaic/browser/static/css/authoring.css
@@ -1,3 +1,5 @@
+/* This is still used by Plone 5 until refactored styles are adapted */
+
 /* @group Tile */
 
 .mosaic-panel {

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.dividers.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.dividers.less
@@ -1,0 +1,59 @@
+.mosaic-divider {
+    position: absolute;
+    z-index: 600;
+    display: none;
+}
+
+.mosaic-divider-top {
+    width: auto;
+    height: 12px;
+    top: -6px;
+    left: -5px;
+    right: 0px;
+    background: url(++resource++plone.app.mosaic.images/divider_horizontal.png) 0px -12px;
+}
+
+.mosaic-divider-bottom {
+    width: auto;
+    height: 12px;
+    left: -5px;
+    right: 0px;
+    top: auto;
+    bottom: -6px;
+    background: url(++resource++plone.app.mosaic.images/divider_horizontal.png) 0px -12px;
+}
+
+.mosaic-divider-right {
+    width: 12px;
+    height: auto;
+    left: auto;
+    right: -6px;
+    top: -5px;
+    bottom: 0px;
+    background: url(++resource++plone.app.mosaic.images/divider_vertical.png) -12px 0px;
+}
+
+.mosaic-divider-left {
+    width: 12px;
+    height: auto;
+    left: -6px;
+    top: -5px;
+    bottom: 0px;
+    background: url(++resource++plone.app.mosaic.images/divider_vertical.png) -12px 0px;
+}
+
+.mosaic-divider-left .mosaic-divider-dot, .mosaic-divider-right .mosaic-divider-dot {
+    background-image: url(++resource++plone.app.mosaic.images/divider_vertical.png);
+    width: 12px;
+    height: 12px;
+}
+
+.mosaic-divider-top .mosaic-divider-dot, .mosaic-divider-bottom .mosaic-divider-dot {
+    background-image: url(++resource++plone.app.mosaic.images/divider_horizontal.png);
+    width: 12px;
+    height: 12px;
+}
+
+.mosaic-selected-divider {
+    display: block !important;
+}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.dragging.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.dragging.less
@@ -1,0 +1,125 @@
+/* Placeholders */
+.mosaic-panel .documentFirstHeading,
+.mosaic-panel .documentDescription {
+    min-height: 1.1875em;
+}
+
+/* Disable text selection */
+.mosaic-blur, .mosaic-panel-dragging {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+
+/* Opacity icons */
+.mosaic-blur {
+    opacity: 0.4;
+}
+
+/* Hover icons */
+.mosaic-tile-control {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    z-index: 500;
+    display: none;
+}
+
+.mosaic-drag-handle {
+    background: transparent none no-repeat center center;
+    top: 0px;
+    bottom: 0px;
+    height: auto;
+    width: auto;
+    left: 0px;
+    right: 0px;
+    cursor: move;
+}
+
+.mosaic-selected-tile .mosaic-drag-handle {
+    z-index: 1;
+}
+
+.mosaic-close-icon {
+    left: -18px;
+    top: -18px;
+    width: 30px;
+    height: 30px;
+    background: url(++resource++plone.app.mosaic.images/window.png) -12px 0px;
+    cursor: pointer;
+    z-index: 501;
+}
+
+.mosaic-info-icon {
+    right: 0px;
+    top: auto;
+    bottom: 0px;
+    background: url(++resource++plone.app.mosaic.images/window.png) -12px -56px;
+    cursor: pointer;
+}
+
+.mosaic-tile:hover .mosaic-field-label {
+    display: block !important;
+}
+
+.mosaic-field-label {
+    top: -2px;
+    left: -252px;
+    width: 250px;
+    color: white;
+    height: 24px;
+    text-align: right;
+}
+
+.mosaic-field-label-left {
+    float: right;
+    width: 6px;
+    height: 24px;
+    background: url(++resource++plone.app.mosaic.images/label.png) 0px -84px;
+}
+
+.mosaic-field-label-content {
+    height: 24px;
+    font-size: 80%;
+    font-weight: bold;
+    line-height: 24px;
+    background: url(++resource++plone.app.mosaic.images/label.png) 0px -108px;
+    float: right;
+    position: relative;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+.mosaic-info-icon:hover {
+    background-position: -28px -56px;
+}
+
+.mosaic-tile:hover .mosaic-tile-control {
+    display: none;
+}
+
+.mosaic-selected-tile .mosaic-tile-control {
+    display: block !important;
+}
+
+/* Show move icon while hovering over a tile */
+.mosaic-tile:hover .mosaic-drag-handle {
+    display: block;
+}
+
+/* Hide icons while dragging or resizing*/
+.mosaic-panel-dragging .mosaic-tile:hover .mosaic-tile-control {
+    display: none;
+}
+
+.mosaic-panel-resizing .mosaic-tile:hover .mosaic-tile-control {
+    display: none;
+}
+
+/* Show move icon on helper */
+.mosaic-helper-tile .mosaic-drag-handle {
+    display: block !important;
+}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.overlays.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.overlays.less
@@ -1,0 +1,28 @@
+.mosaic-hidden {
+    display: none !important;
+}
+
+.mosaic-overlay-blocker {
+    z-index: 2999;
+    width: 100%;
+    height: 100%;
+    opacity: 0.4;
+    background-color: black;
+    display: none;
+    top: 0px;
+    left: 0px;
+    position: fixed;
+    //  _position: absolute;
+    //  _top: expression(eval((document.body.scrollTop)?document.body.scrollTop:document.documentElement.scrollTop));
+}
+
+.mosaic-overlay {
+    display: block;
+    top: 99px;
+    position: fixed;
+    //  _position: absolute;
+    //  _top: expression(eval((document.body.scrollTop)?document.body.scrollTop:document.documentElement.scrollTop));
+    z-index: 3000;
+    padding: 1em;
+    background-color: white;
+}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.resizing.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.resizing.less
@@ -1,0 +1,91 @@
+.mosaic-panel-dragging .mosaic-resize-handle {
+  display: none;
+}
+
+.mosaic-panel-resizing .mosaic-resize-handle-one:hover {
+  display: none;
+}
+
+.mosaic-panel-resizing .mosaic-resize-handle-two:hover {
+    display: none;
+}
+
+.mosaic-panel-resizing {
+    cursor: ew-resize;
+}
+
+.mosaic-row-resizing .mosaic-tile {
+    opacity: 0.5 !important;
+}
+
+.mosaic-resize-handle {
+    position: absolute;
+    height: auto;
+    top: 0px;
+    bottom: 0px;
+    width: 12px;
+    left: -6px;
+    z-index: 500;
+    cursor: ew-resize;
+}
+
+.mosaic-resize-handle:hover {
+    background-image: url(++resource++plone.app.mosaic.images/window.png);
+}
+
+.mosaic-resize-handle-left:hover {
+    background-position: -40px 0px;
+}
+
+.mosaic-resize-handle-center:hover {
+    background-position: -45px 0px;
+}
+
+.mosaic-resize-handle-right:hover {
+    background-position: -50px 0px;
+}
+
+.mosaic-resize-handle.mosaic-resize-handle-helper {
+    background: url(++resource++plone.app.mosaic.images/window.png) 0px 0px;
+}
+
+.mosaic-resize-placeholder {
+    position: absolute;
+    height: 100%;
+}
+
+.mosaic-resize-placeholder-inner-border {
+    position: absolute;
+    border: dotted 1px #888;
+    width: auto;
+    height: auto;
+    z-index: 40;
+    right: 0px;
+    left: 0px;
+    top: 0px;
+    bottom: 0px;
+}
+
+.mosaic-resize-leftmost {
+    margin-left: 0%;
+}
+
+.mosaic-resize-third {
+    margin-left: 33.33%;
+}
+
+.mosaic-resize-two-thirds {
+    margin-left: 66.67%;
+}
+
+.mosaic-resize-quarter {
+    margin-left: 25%;
+}
+
+.mosaic-resize-half {
+    margin-left: 50%;
+}
+
+.mosaic-resize-three-quarters {
+    margin-left: 75%;
+}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.tiles.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.tiles.less
@@ -1,0 +1,200 @@
+.mosaic-panel {
+    position: relative;
+}
+
+/* Outer border */
+.mosaic-panel .mosaic-tile-outer-border {
+    position: absolute;
+    border: solid 2px transparent;
+    width: auto;
+    height: auto;
+    z-index: 40;
+    right: -2px;
+    left: -2px;
+    top: -2px;
+    bottom: -2px;
+    -webkit-border-radius: 2px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+}
+
+/* Inner border */
+.mosaic-panel .mosaic-tile-inner-border {
+    position: absolute;
+    border: solid 1px transparent;
+    width: auto;
+    height: auto;
+    z-index: 40;
+    right: 0px;
+    left: 0px;
+    top: 0px;
+    bottom: 0px;
+}
+
+/* Border on mouse over */
+.mosaic-panel .mosaic-tile:hover .mosaic-tile-outer-border {
+    border: dashed 2px #3469d0;
+}
+
+/* Hide hover border when dragging or resizing*/
+.mosaic-panel .mosaic-panel-dragging .mosaic-tile:hover .mosaic-tile-outer-border {
+    border: solid 2px transparent;
+}
+
+.mosaic-panel .mosaic-panel-resizing .mosaic-tile:hover .mosaic-tile-outer-border {
+    border: solid 2px transparent;
+}
+
+.mosaic-panel .mosaic-panel-resizing .mosaic-selected-tile.mosaic-tile .mosaic-tile-outer-border {
+    border: solid 2px transparent;
+    background-color: transparent;
+}
+
+.mosaic-panel .mosaic-panel-resizing .mosaic-selected-tile.mosaic-tile:hover .mosaic-tile-outer-border {
+    border: solid 2px transparent;
+    background-color: transparent;
+}
+
+.mosaic-panel .mosaic-panel-resizing .mosaic-selected-tile.mosaic-tile .mosaic-tile-control {
+    display: none !important;
+}
+
+/* Selected tile */
+.mosaic-panel .mosaic-selected-tile .mosaic-tile-outer-border {
+    border: 2px solid #3469d0;
+    background-color: #FFFFE1;
+}
+
+.mosaic-panel .mosaic-selected-tile.mosaic-read-only-tile .mosaic-tile-outer-border {
+    border: 2px solid #3469d0;
+    background-color: #F0F0EE;
+}
+
+.mosaic-panel .mosaic-selected-tile.mosaic-read-only-tile:hover .mosaic-tile-outer-border {
+    border: 2px solid #3469d0;
+    background-color: #F0F0EE;
+}
+
+/* Selected tile hover */
+.mosaic-panel .mosaic-selected-tile:hover .mosaic-tile-outer-border {
+    border: 2px solid #3469d0;
+    background-color: #FFFFE1;
+}
+
+/* Other tiles while dragging */
+.mosaic-panel .mosaic-panel-dragging .mosaic-tile .mosaic-tile-inner-border {
+    border: 1px dotted #888;
+}
+
+/* Hide inner border of helper while dragging */
+.mosaic-panel .mosaic-panel-dragging .mosaic-helper-tile .mosaic-tile-inner-border {
+    border: 1px transparent;
+}
+
+.mosaic-panel .mosaic-panel-dragging-new {
+    cursor: crosshair !important;
+}
+
+.mosaic-panel .mosaic-panel-dragging-new:hover {
+    cursor: crosshair !important;
+}
+
+/* Rich text */
+.mosaic-panel .mosaic-rich-text-textarea {
+    width: 100%;
+    border: 0;
+}
+
+/* Images will never be bigger then a tile */
+.mosaic-panel img {
+    max-width: 100%;
+}
+
+/* Uploadprogress */
+.mosaic-tile-uploadprogress {
+    background: rgba(0,0,0,0.6) url(++resource++plone.app.mosaic.images/loading.gif) no-repeat center;
+    position: absolute;
+    z-index: 501;
+    width: auto;
+    height: auto;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
+
+
+/* Helper border */
+.mosaic-panel .mosaic-tile.mosaic-helper-tile {
+    border: 2px solid #3469d0;
+    z-index: 1000;
+    opacity: 0.5;
+    position: absolute;
+}
+
+.mosaic-panel .mosaic-empty-row .mosaic-tile-outer-border {
+    background: url(++resource++plone.app.mosaic.images/divider_horizontal.png) 0px -12px;
+    border: 0px;
+    height: 12px;
+    width: auto;
+    left: -5px;
+    right: 0px;
+}
+
+.mosaic-panel .mosaic-empty-row .mosaic-tile-outer-border .mosaic-divider-dot {
+    background-image: url(++resource++plone.app.mosaic.images/divider_horizontal.png);
+    width: 12px;
+    height: 12px;
+}
+
+.mosaic-panel .mosaic-tile {
+    position: relative;
+    z-index: 100;
+}
+
+.mosaic-panel .mosaic-tile .mosaic-tile-content {
+    position: relative;
+    z-index: 100;
+}
+
+.mosaic-panel .mosaic-tile-content textarea, .mosaic-tile-content input[type=text] {
+    width: 100%;
+}
+
+.mosaic-panel .mosaic-tile-align-left {
+    float: left;
+    z-index: 200;
+}
+
+.mosaic-panel .mosaic-tile-align-right {
+    float: right;
+    z-index: 200;
+}
+
+.mosaic-panel .mosaic-panel-dragging .mosaic-tile-align-left {
+    z-index: 50;
+}
+
+.mosaic-panel .mosaic-panel-dragging .mosaic-tile-align-right {
+    z-index: 50;
+}
+
+.mosaic-panel .mosaic-original-tile {
+    opacity: 0.5;
+}
+
+/* Empty row */
+.mosaic-panel .mosaic-empty-row {
+    height: 12px;
+}
+
+.mosaic-panel .mosaic-empty-row .mosaic-grid-cell {
+    height: 12px;
+    display: none;
+}
+
+.mosaic-panel .mosaic-empty-row .mosaic-grid-cell > div {
+    position: relative;
+    height: 12px;
+}
+/* @end */

--- a/src/plone/app/mosaic/browser/static/css/mosaic.grid.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.grid.less
@@ -1,0 +1,54 @@
+/* Grid classes, these can also be nested */
+.mosaic-grid-row {
+    float: left;
+    width: 100%;
+    display: block;
+    position: relative;
+}
+.mosaic-grid-cell {
+    position: relative;
+    float: left;
+    left: 100%;
+}
+
+/* Widths, these are abstracted out so that pixel-based layouts or other
+   similar approaches can be retrofitted without changing the markup,
+   or if you want to apply rules like the Golden Ratio to your layouts */
+.mosaic-width-full {
+    width: 100%;
+}
+.mosaic-width-half {
+    width: 50%;
+}
+.mosaic-width-quarter {
+    width: 25%;
+}
+.mosaic-width-three-quarters {
+    width: 75%;
+}
+.mosaic-width-third {
+    width: 33.33%;
+}
+.mosaic-width-two-thirds {
+    width: 66.67%;
+}
+
+/* Positioning classes, these are subtracting from a rightmost position */
+.mosaic-position-leftmost {
+    margin-left: -100%;
+}
+.mosaic-position-third {
+    margin-left: -66.67%;
+}
+.mosaic-position-two-thirds {
+    margin-left: -33.33%;
+}
+.mosaic-position-quarter {
+    margin-left: -75%;
+}
+.mosaic-position-half {
+    margin-left: -50%;
+}
+.mosaic-position-three-quarters {
+    margin-left: -25%;
+}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.less
@@ -1,2 +1,3 @@
+/* This is still used by Plone 5 until refactored styles are adapted */
 @import url("toolbar.css");
 @import url("authoring.css");

--- a/src/plone/app/mosaic/browser/static/css/mosaic.pattern.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.pattern.less
@@ -1,0 +1,7 @@
+@import "mosaic.toolbar.less";
+@import "mosaic.authoring.dragging.less";
+@import "mosaic.authoring.dividers.less";
+@import "mosaic.authoring.resizing.less";
+@import "mosaic.authoring.overlays.less";
+@import "mosaic.authoring.tiles.less";
+@import "mosaic.grid.less";

--- a/src/plone/app/mosaic/browser/static/css/mosaic.toolbar.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.toolbar.less
@@ -1,0 +1,78 @@
+@import (reference) "../../../../../../../bower_components/bootstrap/less/bootstrap.less";
+
+.mosaic-toolbar {
+    &:extend(.navbar);
+    &:extend(.navbar-fixed-top);
+
+    fieldset {
+        display: inline;
+
+        margin: 0 1em 0 0;
+        padding: 0;
+        border: 0;
+    }
+
+    button {
+        &:extend(.btn);
+        &:extend(.btn-default);
+        margin: 0 5px 0 0;
+
+        &.mosaic-button-save {
+            &:extend(.btn-success);
+        }
+    }
+
+    .mosaic-menu {
+        margin: 0 5px 0 0;
+        &.mosaic-menu-insert {
+            margin-right: 0;
+        }
+    }
+}
+
+.mosaic-inline-toolbar {
+    position: relative;
+}
+
+.mosaic-toolbar-content {
+    &:extend(.container-fluid);
+    background: #2c6596;
+    background-image: -moz-linear-gradient(top, #2c6596, #3272aa);
+    background-image: -ms-linear-gradient(top, #2c6596, #3272aa);
+    background-image: -o-linear-gradient(top, #2c6596, #3272aa);
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#2c6596), to(#3272aa));
+    background-image: -webkit-linear-gradient(top, #2c6596, #3272aa);
+    background-image: linear-gradient(top, #2c6596, #3272aa);
+    border-top: 1px solid #387fbe;
+    border-bottom: 1px solid #1b3d5b;
+}
+
+.mosaic-toolbar-primary-functions {
+    &:extend(.navbar-form);
+    &:extend(.navbar-left);
+    padding-left: 0;
+    box-shadow: none;
+}
+
+.mosaic-toolbar-secondary-functions {
+    &:extend(.navbar-form);
+    &:extend(.navbar-right);
+    box-shadow: none;
+}
+
+@media screen and (max-width: 768px) {
+    .mosaic-toolbar-primary-functions,
+    .mosaic-toolbar-secondary-functions {
+        padding: 0 15px;
+    }
+}
+
+/* Apply Select2 bootstrap3 styles */
+@import "../../../../../../../bower_components/select2-bootstrap-css/lib/select2-bootstrap.less";
+.mosaic-enabled .select2-results {
+    max-height: none;
+    li.select2-disabled,
+    li.mosaic-option.mosaic-option-none {
+        display: none;
+    }
+}

--- a/src/plone/app/mosaic/browser/static/css/toolbar.css
+++ b/src/plone/app/mosaic/browser/static/css/toolbar.css
@@ -1,3 +1,5 @@
+/* This is still used by Plone 5 until refactored styles are adapted */
+
 /* @group Toolbar */
 
 .mosaic-toolbar {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
@@ -113,8 +113,9 @@ define([
 
                 // Create menu
                 parent.append($(document.createElement("select"))
-                    .addClass("mosaic-menu mosaic-menu-" +
+                    .addClass("mosaic-menu pat-select2 mosaic-menu-" +
                               action.name.replace(/_/g, "-"))
+                    .data("pat-select2", "width: 10em; minimumResultsForSearch: 99;")
                     .data("action", action.action)
                     .change(function () {
                         $(this).mosaicExecAction();


### PR DESCRIPTION
This should be tested on a Plone 5 buildout (@bloodbare, @agitator ?), but this should

- refactor styles into LESS-files
- change tile selector to use pat-select2
- apply some picked bootstrap3 styles for Mosaic Toolbar (includes bower configuration and Makefile to build the final CSS)