### PR TITLE
Change centrally managed, FTI mapped layouts to allow dynamic content by merging them with site layout on rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Changelog
 - Removed "for" in register default profile for sane installation state.
   [agitator]
 
+- Change view method alias support for ++layout++-traversed content layouts
+  so that instead of rendering them as static views, the currently selected
+  content layout is merged to the current site layout before panel merge
+  to allow centrally managed content layouts with layout editor managed areas
+  [datakurre]
+
 - Change text formatting actions from top toolbar to inline TinyMCE toolbars
   [datakurre]
 

--- a/src/plone/app/mosaic/browser/configure.zcml
+++ b/src/plone/app/mosaic/browser/configure.zcml
@@ -32,10 +32,25 @@
       factory=".layoutsupport.DisplayLayoutTraverser"
       />
 
+  <!-- Register content layout traverser for shared static layout support -->
+  <adapter
+      name="staticlayout"
+      factory=".layoutsupport.DisplayStaticLayoutTraverser"
+      />
+
   <!-- Register resource traverser for content layouts -->
   <adapter
       name="contentlayout"
       factory=".layoutsupport.DisplayContentLayoutTraverser"
+      />
+
+  <!-- Customize page-site-layout to merge content layout -->
+  <browser:view
+      name="page-site-layout"
+      for="*"
+      layer="..interfaces.IMosaicLayer"
+      class=".layoutsupport.PageSiteLayoutView"
+      permission="zope.Public"
       />
 
   <browser:menu

--- a/src/plone/app/mosaic/widget.py
+++ b/src/plone/app/mosaic/widget.py
@@ -45,13 +45,14 @@ class LayoutWidget(BaseWidget, TextAreaWidget):
     def enabled(self):
         # Disable Mosaic editor when the selected layout for the current
         # ILayoutAware or DX add form context is not custom layout
-        current_browser_layout = (
-            self._add_form_portal_type_default_view()
-            or self._context_selected_layout()
-        )
-        if current_browser_layout not in ['', 'view', '@@view']:
+        add_form_layout = self._add_form_portal_type_default_view()
+        edit_form_layout = self._context_selected_layout()
+        if edit_form_layout.startswith('++layout++'):
+            return True
+        elif (add_form_layout or edit_form_layout) in ['', 'view', '@@view']:
+            return True
+        else:
             return False
-        return True
 
     def obtainType(self):  # noqa
         """


### PR DESCRIPTION
To be discussed, but not necessarily to be merged yet. Would require example layouts to be updated with examples that make some sense with this.

@vangheem You should try this branch, before continuing, next time you are on Mosaic. /cc @agitator 

Your issue with the centrally managed, FTI mapped (++layout++ mappings in method aliases) layouts was that they were static and completely ignored the layout editor managed content instance specific layout. This would solve that, but with more features would come more complexity...

With this, when a ++layout++-mapped content layout is selected from display menu, it is panel merged with the current site layout (main_template) already in @@page-site-layout (layout indirection used in each content layout by default) and the real panel merge is done against the content instance specific, layout editor managed layout.

But this changes what is expected from the content layouts in ++layout++-mappings.

Currently, each content layout specify their layout in single

     <div data-panel="content">...</div>

because there are not other panels available with main_template. Also, I've instructed mostly to create those layouts with the layout editor so that they would be also usable as default layout value with the special ++layout++default -mapping.

Now, when ++layout++-mapped layouts are merged, they should define additional panels within data-panel="content", one of those panels should also be named "content". Also, the HTML syntax of these layouts no longer matters, but they are not compatible to be used as ++layout++default:

     <div data-panel="content">...<div data-panel="content"></div>...<div data-panel="other"></div>...</div>

I'm sorry for the need for that fixed "content" panel, but it's required for backwards compatibility for all non-Mosaic layouts and templates on Plone.

Now, on view and edit form the contents of the outmost panel would be rendered as blurred content
as it was part of site layouts and those nested panels are editable (and could get their default values from ++layout++default-mapping). Different layouts may have different content for the outmost panel, position nested panels differently, but as long as the panels names stay the same, layouts can be changed on the fly without the need to care about any kind of merging content instance layout.

![nayttokuva 2015-08-13 kello 4 56 10](https://cloud.githubusercontent.com/assets/160447/9241129/def35826-4177-11e5-8588-7e65c498118b.png)

**Known issues:** Layout editor is not supported on add forms for content types with ++layout++-based view as their default view, but a normal add form is shown. That's because it would prevent using (transient) tiles in static/shared areas in those layouts (add form does not have context yet and rendering of those tiles would fail). It may also be confusing that even the shared layout already uses field tiles, layout editor will still show all field tiles available (because it doesn't understand yet that part of the field tiles have been rendered already in site layout). For the same reason, inline editing of fields in blurred area is not possible. (Not sure if it would make sense to make it work.)

So, we would end up having two flavors of content layouts. Centrally managed layouts with nested panels, and layout editor compatible layouts. This might be an issue, yet might be possible to be handled with annotations in layout manifest.cfg.

This change does not affect current "Custom layout" behavior.