### PR TITLE
If the content layout is changed, update the state of the HTML for th…

### DIFF
--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -155,8 +155,8 @@ define([
     return $($.mosaic.options.contentLayout_field_selector).val();
   };
 
-  $.mosaic.setSelectedContentLayout = function(value){
-    if(value){
+  $.mosaic.setSelectedContentLayout = function(path, html){
+    if(path){
       $.mosaic.hasContentLayout = true;
       // Need to hide these buttons when not in custom content layout mode
       $('.mosaic-toolbar-secondary-functions', $.mosaic.document).hide();
@@ -165,7 +165,10 @@ define([
       $('body').addClass('mosaic-layout-customized');
       $.mosaic.hasContentLayout = false;
     }
-    return $($.mosaic.options.contentLayout_field_selector).attr('value', value);
+    // Update the textarea that stores the layout HTML state
+    $($.mosaic.options.customContentLayout_field_selector).val(html);
+    // Update the input field that stores the contentLayout
+    $($.mosaic.options.contentLayout_field_selector).attr('value', path);
   };
 
 
@@ -198,7 +201,6 @@ define([
   };
 
   $.mosaic._init = function (content) {
-    
     $.mosaic._initPanels(content);
 
     // Init overlay
@@ -217,7 +219,7 @@ define([
 
     // Init layout
     $.mosaic.options.panels.mosaicLayout();
-    
+
     // Add blur to the rest of the content
     $("*", $.mosaic.document).each(function () {
 
@@ -276,7 +278,7 @@ define([
       url: $.mosaic.options.context_url + '/' + layoutPath
     }).done(function(layoutHtml){
       var $content = $.mosaic.getDomTreeFromHtml(layoutHtml);
-      $.mosaic.setSelectedContentLayout(layoutPath);
+      $.mosaic.setSelectedContentLayout(layoutPath, layoutHtml);
       if($.mosaic.loaded){
         // initialize panels
         $.mosaic._initPanels($content);


### PR DESCRIPTION
If the content layout is changed, update the state of the HTML for that content layout.

Without this, what was happening is that the layout kept reverting to the original layout in https://github.com/neilferreira/plone.app.mosaic/blob/34fa50aff30e77c7d4c15a93f8a378ac68ba2b3c/src/plone/app/mosaic/browser/static/js/mosaic.core.js#L138