### PR TITLE
Added ability for a layout to have a maximum amount of columns set

### DIFF
--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -906,7 +906,7 @@ define([
           .addClass("mosaic-new-tile");
       }
     // Check if max columns rows is reached
-    } else if ((drop.parent().parent().children(".mosaic-grid-cell").length === 4) && (dir === "left" || dir === "right")) {
+    } else if ((drop.parent().parent().children(".mosaic-grid-cell").length >= obj.data('max-columns')) && (dir === "left" || dir === "right")) {
       // Remove remaining empty rows
       $(".mosaic-empty-row", $.mosaic.document).remove();
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -410,6 +410,12 @@ define([
           if ((dir === "left") || (dir === "right")) {
             var row = divider.parent().parent().parent();
 
+            if (row.children(".mosaic-grid-cell").length >= $('.mosaic-panel').data('max-columns')) {
+                // This row already up to the max amount of columns allowed for this layout
+                // do not allow this item to be dropped alingside any elements in this row
+                return;
+            }
+
             // If row has multiple columns
             if (row.children(".mosaic-grid-cell").length > 1) {
               divider.height(row.height() + 5);
@@ -899,10 +905,8 @@ define([
           .removeClass("mosaic-original-tile")
           .addClass("mosaic-new-tile");
       }
-
     // Check if max columns rows is reached
     } else if ((drop.parent().parent().children(".mosaic-grid-cell").length === 4) && (dir === "left" || dir === "right")) {
-
       // Remove remaining empty rows
       $(".mosaic-empty-row", $.mosaic.document).remove();
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -1706,8 +1706,7 @@ define([
       position = 1,
       size = 12,
       body = "",
-      classNames = "",
-      panel_id = "";
+      classNames = "";
 
     // Disable edit html source
     $.mosaic.disableEditHtmlSource();
@@ -1719,8 +1718,8 @@ define([
     $("[data-panel]", $.mosaic.document).each(function () {
 
       // Add open panel tag
-      panel_id = $(this).attr("data-panel");
-      body += '    <div data-panel="' + panel_id + '">\n';
+      body += '    <div data-panel="' + $(this).data("panel") + '"'
+      body += '         data-max-columns="' + $(this).data("max-columns") + '">\n';
 
       // Loop through rows
       $(this).children(".mosaic-grid-row").each(function () {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
@@ -18,9 +18,9 @@ define([
 
   Panel.prototype.initialize = function($content){
     // Local variables
-    var panel_id = this.$el.attr("data-panel"), panel_attr_id,
-        target = $("[data-panel=" + panel_id + "]",
-        $.mosaic.document);
+    var panel_id = this.$el.data("panel"), panel_attr_id,
+        target = $("[data-panel=" + panel_id + "]", $.mosaic.document),
+        max_columns = (this.$el.data('max-columns') || 4);
 
     // Implicitly initialize required panels with id matching element
     if (panel_id === 'content' && target.length === 0) {
@@ -40,6 +40,7 @@ define([
             .attr("class", target.attr("class"))
             .addClass('mosaic-panel')
             .attr('data-panel', 'content')
+            .attr('data-max-columns', max_columns)
             .html($content.find("[data-panel=" + panel_id + "]").html()));
         target
             .removeAttr('data-panel')
@@ -52,6 +53,7 @@ define([
             .attr("class", target.attr("class"))
             .addClass('mosaic-panel')
             .attr('data-panel', 'content')
+            .attr('data-max-columns', max_columns)
             .html($content.find("[data-panel=" + panel_id + "]").html()));
       }
     } else {

--- a/src/plone/app/mosaic/layouts/plone-5/content/basic.html
+++ b/src/plone/app/mosaic/layouts/plone-5/content/basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" data-layout="./@@page-site-layout">
 <body>
-<div data-panel="content">
+<div data-panel="content" data-max-columns="4">
   <div class="mosaic-grid-row">
     <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
       <div class="movable removable mosaic-tile mosaic-IDublinCore-title-tile">


### PR DESCRIPTION
Defaults to the current amount of  4.

The current functionality limits the max columns to 4 but still allows users to keep dropping more columns and it feels rather buggy.  This disabled disable the ability to drop another tile on the left or right if the max has been reached.