### PR TITLE
Revert "Added some basic documentation on how to use the functionality to hide a layout from a specific content type."

### DIFF
--- a/src/plone/app/mosaic/utils.py
+++ b/src/plone/app/mosaic/utils.py
@@ -99,17 +99,6 @@ def getContentLayoutsForType(pt):
     for item in hidden[:]:
         # undocumented feature right now.
         # need to figure out how to integrate into UI yet
-        # For type "Homepage"
-        # <record name="plone.app.mosaic.hidden_content_layouts">
-        #   <field type="plone.registry.field.List">
-        #     <title>Hidden content layouts</title>
-        #     <value_type type="plone.registry.field.TextLine" />
-        #   </field>
-        #   <value purge="true">
-        #     <element>custom/basic.html</element>
-        #     <element>default/basic.html::Homepage</element>
-        #   </value>
-        # </record>
         if '::' in item:
             # seperator to be able to specify hidden for a specific type
             key, _, hidden_type = item.partition('::')


### PR DESCRIPTION
Reverts plone/plone.app.mosaic#166

These were minor additions, but @neilferreira didn't CLA, so I need to add these later myself.