### PR TITLE
Fix case where you could get an error on save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,11 @@ New:
 
 Fixes:
 
-- Fix TinyMCE widget in add-form which was broken due to a change how the 
+- Fix case where you could get an error on save because mosaic could not figure out
+  the tile type correctly
+  [vangheem]
+
+- Fix TinyMCE widget in add-form which was broken due to a change how the
   settings are stored in Plone 5 vs 4. BBB compatible.
   [jensens]
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -174,7 +174,8 @@ define([
               (classname[1] !== 'new') &&
               (classname[1] !== 'read-only') &&
               (classname[1] !== 'helper') &&
-              (classname[1] !== 'original')) {
+              (classname[1] !== 'original') &&
+              (classname[1] !== 'edited')) {
             tiletype = classname[1];
           }
         }
@@ -249,6 +250,7 @@ define([
         case "mosaic-helper-tile":
         case "mosaic-original-tile":
         case "mosaic-selected-tile":
+        case "mosaic-edited-tile":
           return false;
         default:
           return true;


### PR DESCRIPTION
This can happen occasionally.

We still probably need some better safe guards against bad tiles in the layout or tiles that have lost configuration and not throwing errors(which would not allow users to save).

But this is a simple fix.