### PR TITLE
Fix issue where iframes in TinyMCE text tile content were broke

### DIFF
--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -289,13 +289,15 @@ define([
 
     // Get tile config
     var tile_config = this.getConfig();
+    var editor;
 
     // Predefine vars
     switch (tile_config.tile_type) {
       case "text":
+        editor = tinymce.get(this.$el.children(".mosaic-tile-content").attr('id'));
         body += '          <div class="' + classes.join(' ') + '">\n';
         body += '          <div class="mosaic-tile-content">\n';
-        body += this.$el.children(".mosaic-tile-content").html().replace(/^\s+|\s+$/g, '') + "\n";
+        body += (editor ? editor.getContent() : this.$el.children(".mosaic-tile-content").html()).replace(/^\s+|\s+$/g, '') + "\n";
         body += '          </div>\n';
         body += '          </div>\n';
         break;


### PR DESCRIPTION
Because of Deco legacy, I assume, we've been naively saving HTML from DOM when saving text tiles. Unfortunately, TinyMCE may decorate that HTML with wrapper, for example, when edited content contains iframe embeds.

This pull looks up for possible TinyMCE editor for the tile before falling back to just saving the HTML (which is the case when the tile has not been edited, I recall).
