### PR TITLE
Add preview action [fixes #99]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-- provide better use of permissions in UI and enforcements on the server
+- Add preview button for previewing currently edited layout
+  [datakurre]
+
+- Provide better use of permissions in UI and enforcements on the server
   [vangheem]
 
 - Fix problem where layouts could be saved without a name

--- a/docs/registry.rst
+++ b/docs/registry.rst
@@ -23,3 +23,32 @@ example, the following configuration will
        <element>default/basic.html::MyPortalType</element>
      </value>
    </record>
+
+
+Enabling review action
+----------------------
+
+Mosaic includes a layout preview action (for previewing the
+currently edited layout without the editor) in Layout menu
+button. It's hidden by default, but can be enabled with the
+following registry.xml entry:
+
+.. code:: xml
+
+  <record name="plone.app.mosaic.default_available_actions">
+    <value purge="false">
+      <element>preview</element>
+    </value>
+  </record>
+
+
+In addition, preview action can be moved out of the layout as a separate
+toolbar button with:k
+
+.. code:: xml
+
+  <records prefix="plone.app.mosaic.primary_actions.preview"
+           interface='plone.app.mosaic.interfaces.IAction'>
+    <value key="fieldset"></value>
+    <value key="weight">40</value>
+  </records>

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -299,6 +299,23 @@ define([
       }
     });
 
+    // Register preview action
+    $.mosaic.registerAction('preview', {
+      exec: function () {
+
+        // Trigger validation => drafting sync
+        $("#form-widgets-ILayoutAware-customContentLayout, " +
+            "[name='form.widgets.ILayoutAware.customContentLayout']")
+            .focus().blur();
+
+        // Layout preview
+        setTimeout(function(){
+          window.open(
+              $.mosaic.options.context_url + '/@@layout_preview', '_blank');
+        }, 1000);
+      }
+    });
+
     // Register html action
     $.mosaic.registerAction('html', {
       exec: function () {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -311,7 +311,7 @@ define([
         // Layout preview
         setTimeout(function(){
           window.open(
-              $.mosaic.options.context_url + '/@@layout_preview', '_blank');
+              $.mosaic.options.context_url + '/@@preview', '_blank');
         }, 1000);
       }
     });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -311,7 +311,7 @@ define([
         // Layout preview
         setTimeout(function(){
           window.open(
-              $.mosaic.options.context_url + '/@@preview', '_blank');
+              $.mosaic.options.context_url + '/@@layout_preview', '_blank');
         }, 1000);
       }
     });

--- a/src/plone/app/mosaic/profiles/default/registry.xml
+++ b/src/plone/app/mosaic/profiles/default/registry.xml
@@ -45,6 +45,17 @@
     <value key="weight">30</value>
   </records>
 
+  <records prefix="plone.app.mosaic.primary_actions.preview"
+           interface='plone.app.mosaic.interfaces.IAction'>
+    <value key="name">preview</value>
+    <value key="fieldset">Layout</value>
+    <value key="label">Preview</value>
+    <value key="action">preview</value>
+    <value key="icon">False</value>
+    <value key="menu">False</value>
+    <value key="weight">20</value>
+  </records>
+
   <records prefix="plone.app.mosaic.primary_actions.customizelayout"
            interface='plone.app.mosaic.interfaces.IAction'>
     <value key="name">customizelayout</value>
@@ -76,17 +87,6 @@
     <value key="icon">False</value>
     <value key="menu">False</value>
     <value key="weight">60</value>
-  </records>
-
-  <records prefix="plone.app.mosaic.primary_actions.preview"
-           interface='plone.app.mosaic.interfaces.IAction'>
-    <value key="name">preview</value>
-    <value key="fieldset"></value>
-    <value key="label">Preview</value>
-    <value key="action">preview</value>
-    <value key="icon">False</value>
-    <value key="menu">False</value>
-    <value key="weight">50</value>
   </records>
 
   <records prefix="plone.app.mosaic.secondary_actions.format"
@@ -138,7 +138,6 @@
       <element>customizelayout</element>
       <element>changelayout</element>
       <element>savelayout</element>
-      <element>preview</element>
       <element>format</element>
       <element>insert</element>
       <element>tile-align-center</element>

--- a/src/plone/app/mosaic/profiles/default/registry.xml
+++ b/src/plone/app/mosaic/profiles/default/registry.xml
@@ -78,6 +78,17 @@
     <value key="weight">60</value>
   </records>
 
+  <records prefix="plone.app.mosaic.primary_actions.preview"
+           interface='plone.app.mosaic.interfaces.IAction'>
+    <value key="name">preview</value>
+    <value key="fieldset"></value>
+    <value key="label">Preview</value>
+    <value key="action">preview</value>
+    <value key="icon">False</value>
+    <value key="menu">False</value>
+    <value key="weight">50</value>
+  </records>
+
   <records prefix="plone.app.mosaic.secondary_actions.format"
            interface='plone.app.mosaic.interfaces.IAction'>
     <value key="name">format</value>
@@ -127,6 +138,7 @@
       <element>customizelayout</element>
       <element>changelayout</element>
       <element>savelayout</element>
+      <element>preview</element>
       <element>format</element>
       <element>insert</element>
       <element>tile-align-center</element>


### PR DESCRIPTION
With the latest plone.app.drafting (>= 1.1.0) and plone.app.tiles master and plone.app.blocks master, this pull adds preview button into toolbar, which 1) syncs current layout with draft storage 2) opens preview in a new window.

The preview view itself is already implemented plone.app.blocks and this only adds a shortcut for synchronizing and opening preview. If toolbar is already too crowdy, something else could be implemented instead.