### PR TITLE
Fix mark_view call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Fixes problems introduces with grid responsive styles
   [agitator]
+- ``plone_view/mark_view`` was deprecated and removed.
+  Use ``plone_layout/mark_view`` instead.
+  [thet]
 
 - Fix issue where incomplete mosaic-grid bundle definition broke
   Plone bundle merge

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Fixes problems introduces with grid responsive styles
   [agitator]
+
 - ``plone_view/mark_view`` was deprecated and removed.
   Use ``plone_layout/mark_view`` instead.
   [thet]

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -37,10 +37,10 @@ TEMPLATE = """\
         portal_state context/@@plone_portal_state;
         context_state context/@@plone_context_state;
         plone_view context/@@plone;
-        plone_layout context/@@plone_layout | nothing;
+        plone_layout context/@@plone_layout;
         lang portal_state/language;
         view nocall: view | nocall: plone_view;
-        dummy python:plone_view.mark_view(view);
+        dummy python:plone_layout.mark_view(view);
         portal_url portal_state/portal_url;
         checkPermission nocall: context/portal_membership/checkPermission;
         site_properties nocall: context/portal_properties/site_properties;


### PR DESCRIPTION
``plone_view/mark_view`` was removed.
Use ``plone_layout/mark_view`` instead.

Related: https://github.com/plone/plone.app.tiles/pull/21

This fixes bugs caused by a change in CMFPlone: https://github.com/plone/Products.CMFPlone/pull/1838 