### PR TITLE
Thet bodyclassfix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changelog
 ---------------------
 
 New features:
+- ``plone_view/mark_view`` was deprecated and removed.
+  Use ``plone_layout/mark_view`` instead.
+  [thet]
+
+- Fix issue where incomplete mosaic-grid bundle definition broke
+  Plone bundle merge
+  [datakurre]
 
 - Show layouts description in Mosaic Select Layout overlay
   [annegilles]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,21 @@ Changelog
 ---------------------
 
 New features:
+Breaking changes:
+
+- Nothing changed yet.
+
+New features:
+
+- In the ``BodyClass`` transform, retrieve the content layout path from ILayoutAware provided method which also considers default paths registered in the registry.
+  Fixes no layout classes added to the body tag with default content layouts for types.
+  [thet]
+
+- Show layouts description in Mosaic Select Layout overlay
+  [annegilles]
+
+Bug fixes:
+
 - ``plone_view/mark_view`` was deprecated and removed.
   Use ``plone_layout/mark_view`` instead.
   [thet]
@@ -22,6 +37,7 @@ New features:
 Bug fixes:
 
 - Fixes problems introduces with grid responsive styles
+- Fix grid responsive styles
   [agitator]
 
 - ``plone_view/mark_view`` was deprecated and removed.

--- a/src/plone/app/mosaic/transform.py
+++ b/src/plone/app/mosaic/transform.py
@@ -152,10 +152,18 @@ class BodyClass(object):
             ])
 
         # Get contentLayout body class
-        if 'template-layout' in body_classes:
+        if (
+            'template-layout' in body_classes or
+            'template-layout_view' in body_classes
+        ):
             adapted = ILayoutAware(context, None)
             if adapted is not None:
-                layout = getattr(adapted, 'contentLayout', None)
+                layout = None
+                if getattr(adapted, 'content_layout_path', False):
+                    # plone.app.blocks > 4.0.0rc1
+                    layout = adapted.content_layout_path()
+                else:
+                    layout = getattr(adapted, 'contentLayout', None)
                 if layout:
                     # Transform ++contentlayout++default/document.html
                     # into layout-default-document


### PR DESCRIPTION
- In the ``BodyClass`` transform, retrieve the content layout path from ILayoutAware provided method which also considers default paths registered in the registry.
  Fixes no layout classes added to the body tag with default content layouts for types.

This PR builds upon https://github.com/plone/plone.app.mosaic/pull/311 which is not merged because of unrelated travis errors.

This PR relates to the following and should be merged together withe these:
https://github.com/plone/plone.app.blocks/pull/47
https://github.com/plone/plone.app.layout/pull/105