### PR TITLE
Fix to disable layout editor widget when form has a message (usually an error)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Bug fixes:
 
 - Fix issue where default layouts did not work properly, because they were
   registered as unicode strings when encoded ASCII strings were required
+  [datakurre]
+
 - Fix to disable layout editor when edit form has a status message
   (which is usually a validation error message) as workaround for
   editor not being able to display validation errors

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 WARNING: Migration from 1.0.0 to 2.0.0 may still have unsolved issues.
 
+Breaking changes:
+
+- No changes yet.
+
 New features:
 
 - No changes yet.
@@ -14,6 +18,9 @@ Bug fixes:
 
 - Fix issue where default layouts did not work properly, because they were
   registered as unicode strings when encoded ASCII strings were required
+- Fix to disable layout editor when edit form has a status message
+  (which is usually a validation error message) as workaround for
+  editor not being able to display validation errors
   [datakurre]
 
 

--- a/src/plone/app/mosaic/widget.py
+++ b/src/plone/app/mosaic/widget.py
@@ -54,6 +54,11 @@ class LayoutWidget(BaseWidget, TextAreaWidget):
     @property
     @memoize
     def enabled(self):
+        # Disable Mosaic editor when the form has a status message,
+        # because the Mosaic editor is currently unable to properly show
+        # validation errors
+        if self._form_status():
+            return False
         # Disable Mosaic editor when the selected layout for the current
         # ILayoutAware or DX add form context is not custom layout
         current_browser_layout = (
@@ -187,6 +192,18 @@ class LayoutWidget(BaseWidget, TextAreaWidget):
         if not selectable_layout:
             return ''
         return selectable_layout.getLayout()
+
+    def _form_status(self):
+        """Return the current status message of the underlying form"""
+        try:
+            return self.form._parent.status
+        except AttributeError:
+            pass
+        try:
+            return self.form.status
+        except AttributeError:
+            pass
+        return u''
 
 
 @adapter(getSpecification(ILayoutAware['customContentLayout']), IMosaicLayer)


### PR DESCRIPTION
fixes #290 

/cc @tomgross 