### PR TITLE
Fix issue where Mosaic transforms fired for ESI helper views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Changelog
 
 - Remove unneeded unittest2 imports
   [tomgross]
+- Fix where Mosaic transforms did fire for ESI requests for ESI
+  tile helper views
+  [datakurre]
+
 
 2.0.0rc4 (2016-12-13)
 ---------------------

--- a/src/plone/app/mosaic/configure.zcml
+++ b/src/plone/app/mosaic/configure.zcml
@@ -57,31 +57,58 @@
           />
   </class>
 
-
   <!-- HTTPHeaders transform, because main_template may not be rendered -->
   <adapter
-      for="* .interfaces.IMosaicLayer"
+      for="*
+           plone.app.blocks.interfaces.IBlocksTransformEnabled"
+      name="plone.app.mosaic.httpheaders"
+      factory=".transform.HTTPHeaders"
+      />
+  <adapter
+      for="plone.app.blocks.interfaces.IBlocksTransformEnabled
+           .interfaces.IMosaicLayer"
       name="plone.app.mosaic.httpheaders"
       factory=".transform.HTTPHeaders"
       />
 
   <!-- HTML language transform to fix language attribute in site layout -->
   <adapter
-      for="* .interfaces.IMosaicLayer"
+      for="*
+           plone.app.blocks.interfaces.IBlocksTransformEnabled"
+      name="plone.app.mosaic.language"
+      factory=".transform.HTMLLanguage"
+      />
+  <adapter
+      for="plone.app.blocks.interfaces.IBlocksTransformEnabled
+           .interfaces.IMosaicLayer"
       name="plone.app.mosaic.language"
       factory=".transform.HTMLLanguage"
       />
 
   <!-- Body class transform to add traditional Plone body class -->
   <adapter
-      for="* .interfaces.IMosaicLayer"
+      for="*
+           plone.app.blocks.interfaces.IBlocksTransformEnabled"
+      name="plone.app.mosaic.bodyclass"
+      factory=".transform.BodyClass"
+      />
+  <adapter
+      for="plone.app.blocks.interfaces.IBlocksTransformEnabled
+           .interfaces.IMosaicLayer"
       name="plone.app.mosaic.bodyclass"
       factory=".transform.BodyClass"
       />
 
   <!-- Body data-pat-* transform to pattern settings -->
   <adapter
-      for="* .interfaces.IMosaicLayer"
+      for="*
+           plone.app.blocks.interfaces.IBlocksTransformEnabled"
+      name="plone.app.mosaic.patternsettings"
+      factory=".transform.PatternSettings"
+      />
+  <adapter
+      for="plone.app.blocks.interfaces.IBlocksTransformEnabled
+           .interfaces.IMosaicLayer"
       name="plone.app.mosaic.patternsettings"
       factory=".transform.PatternSettings"
       />


### PR DESCRIPTION
And refactor Mosaic transforms.

Transform conditions are a bit of a mess.

At first, we should follow plone.app.blocks' registrations and register transform only when IBlocksTransformEnabled is set either on request or published object. I know this makes registration look a bit complex, but it optimizes transform lookup in plone.transformchain. Unfortunate side effect is that we should check existence IMosaicLayer manually  in transform code.

Yet, we have bunch of conditions anyway: Some sanity checks that we are on a real object and we have plone.app.blocks parsed result tree (these probably could be optimized and trust that everything is ok when plone.app.blocks.enabled is set). A new check is check for plone.app.blocks.disabled, which is set for ESI tile requests.