### PR TITLE
Add support for 'permission' in content layout manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.0rc5 (unreleased)
 ---------------------
 
+- Add support for optiona ``permission``-key in content layout manifests
+  [datakurre]
+
 - Fix issue where global TinyMCE setting for paste_as_text was not
   respected
   [datakurre]
@@ -13,7 +16,8 @@ Changelog
 
 - Remove unneeded unittest2 imports
   [tomgross]
-- Fix where Mosaic transforms did fire for ESI requests for ESI
+
+- Fix issue where Mosaic transforms did fire for ESI requests for ESI
   tile helper views
   [datakurre]
 

--- a/src/plone/app/mosaic/browser/editor.py
+++ b/src/plone/app/mosaic/browser/editor.py
@@ -112,7 +112,8 @@ class ManageLayoutView(BrowserView):
                     self.context.portal_type
                 ),
                 'available_layouts': getContentLayoutsForType(
-                    self.context.portal_type
+                    self.context.portal_type,
+                    self.context
                 )
             }
         )
@@ -208,7 +209,8 @@ class ManageLayoutView(BrowserView):
                     self.context.portal_type
                 ),
                 'available_layouts': getContentLayoutsForType(
-                    self.context.portal_type
+                    self.context.portal_type,
+                    self.context
                 )
             }
         )

--- a/src/plone/app/mosaic/utils.py
+++ b/src/plone/app/mosaic/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from AccessControl.security import checkPermission
 from plone.app.blocks.interfaces import CONTENT_LAYOUT_MANIFEST_FORMAT
 from plone.app.blocks.interfaces import CONTENT_LAYOUT_RESOURCE_NAME
 from plone.app.blocks.interfaces import IOmittedField
@@ -98,7 +99,7 @@ def extractFieldInformation(schema, context, request, prefix):
                 }
 
 
-def getContentLayoutsForType(pt):
+def getContentLayoutsForType(pt, context=None):
     result = []
     registry = getUtility(IRegistry)
     hidden = registry.get('plone.app.mosaic.hidden_content_layouts', [])[:]
@@ -123,6 +124,10 @@ def getContentLayoutsForType(pt):
                 [os.path.dirname(key), preview])
         value['path'] = key
         result.append(value)
+    if context is not None:
+        result = [value for value in result
+                  if not value.get('permission') or
+                  checkPermission(value.get('permission'), context)]
     result.sort(key=lambda l: l.get('sort_key', '') or l.get('title', ''))
     return result
 

--- a/src/plone/app/mosaic/widget.py
+++ b/src/plone/app/mosaic/widget.py
@@ -133,7 +133,7 @@ class LayoutWidget(BaseWidget, TextAreaWidget):
             self.name.replace('.customContentLayout', '.contentLayout')
         )
 
-        result['available_layouts'] = getContentLayoutsForType(pt)
+        result['available_layouts'] = getContentLayoutsForType(pt, self.context)  # noqa
         result['user_layouts'] = getUserContentLayoutsForType(pt)
 
         return {'data': result}


### PR DESCRIPTION
and filter available layouts in menus by that permission.

Layouts without or empty permission remain visible for everyone with permission to change layout.

Requires https://github.com/plone/plone.app.blocks/pull/53 to be really functional.