### PR TITLE
Add editable static panels, content layout specific site layouts and custom field tiles support

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -183,15 +183,13 @@ like the publishing date or the short name.
        Run keyword and ignore error  Set window size  1024  1200
        Wait Until Element Is Visible  css=.mosaic-toolbar
        Click element  css=.mosaic-button-properties
-       
+       Wait Until Element Is Visible  css=.plone-modal-content
+
        Highlight  css=.autotoc-nav
 
        Capture and crop page screenshot
        ...  _screenshots/mosaic-editor-properties-modal.png
        ...  css=.plone-modal-content
-
-       #...  css=html
-       #.plone-modal-content
        Run keyword and ignore error  Set window size  1024  800
        Click element  css=.mosaic-overlay-ok-button
 

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -264,7 +264,7 @@ class MainTemplate(BrowserView):
         else:
             try:
                 return self.layout
-            except (NotFound, IOError):
+            except (AssertionError, NotFound, IOError):
                 if self.request.form.get('ajax_load'):
                     return self.ajax_template
                 else:
@@ -275,6 +275,7 @@ class MainTemplate(BrowserView):
         # Resolve layout path from data-layout of content (or the default)
         layout_aware = ILayoutAware(self.context, None)
         content_layout = layout_aware.content_layout()
+        assert content_layout is not None
         html_parser = html.HTMLParser(encoding='utf-8')
         html_tree = html.fromstring(content_layout, parser=html_parser)
         layout_path = xpath1(layoutXPath, html_tree.getroottree())

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -264,7 +264,7 @@ class MainTemplate(BrowserView):
         else:
             try:
                 return self.layout
-            except NotFound:
+            except (NotFound, IOError):
                 if self.request.form.get('ajax_load'):
                     return self.ajax_template
                 else:

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -293,7 +293,9 @@ class MainTemplate(BrowserView):
             # always return either the global default ajax layout or fallback
             # to legacy ajax_loa aware template
             layout_path = registry.get(DEFAULT_AJAX_LAYOUT_REGISTRY_KEY)
-        if re.match(r'.*/@*edit$', url) or state.is_view_template():
+        if re.match(r'.*/@*edit$', url) or (
+                state.view_template_id() == 'layout_view' and
+                state.is_view_template()):
             # Resolve layout path from data-layout of content
             layout_aware = ILayoutAware(self.context, None)
             content_layout = layout_aware.content_layout()

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -281,7 +281,13 @@ class MainTemplate(BrowserView):
         layout_path = xpath1(layoutXPath, html_tree.getroottree())
 
         # Resolve layout path into layout
-        layout = resolveResource(layout_path)
+        if not self.request.get('ajax_load'):
+            layout = resolveResource(layout_path)
+        else:
+            if '?' not in layout_path:
+                layout = resolveResource(layout_path + '?ajax_load=1')
+            else:
+                layout = resolveResource(layout_path + '&ajax_load=1')
 
         # Cook main_template from layout
         cooked = cook_layout(layout, self.request.get('ajax_load'))

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -323,7 +323,7 @@ class MainTemplate(BrowserView):
             # always return either the global default ajax layout or fallback
             # to legacy ajax_loa aware template
             layout_path = registry.get(DEFAULT_AJAX_LAYOUT_REGISTRY_KEY)
-        if re.match(r'.*/@*edit$', url) or (
+        elif re.match(r'.*/@*edit$', url) or (
                 state.view_template_id() == 'layout_view' and
                 state.is_view_template()):
             # Resolve layout path from data-layout of content

--- a/src/plone/app/mosaic/browser/static/css/mosaic.authoring.overlays.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.authoring.overlays.less
@@ -29,7 +29,14 @@
   bottom: 0;
   left: 0;
 
-  .mosaic-modal {
+  label .required.radio-widget::after {
+    content: '';
+  }
+
+  .plone-modal.mosaic-modal {
+    display: flex;
+    align-items: center;
+    align-content: center;
     overflow-x: hidden;
     overflow-y: auto;
     background: none;
@@ -38,6 +45,7 @@
     bottom: 0;
     left: 0;
   }
+
   .plone-modal-dialog{
     width: 80%;
     margin-right: auto !important;
@@ -46,17 +54,3 @@
     top: 0;
   }
 }
-
-.plone-modal-wrapper {
-  label .required.radio-widget::after {
-    content: '';
-  }
-}
-
-//.mosaic-overlay-ok-button {
-//  &:extend(.btn);
-//  &:extend(.btn-primary);
-//  &:hover {
-//    &:extend(.btn-primary:hover);
-//  }
-//}

--- a/src/plone/app/mosaic/browser/static/css/mosaic.toolbar.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.toolbar.less
@@ -167,7 +167,7 @@
 
   /* Fix dropdown positioning */
   position: fixed !important;
-  top: 53px !important;
+  top: 50px !important;
   left: auto !important;
   right: 0 !important;
 
@@ -210,7 +210,10 @@
         font-size: 125%;
         text-align: center;
       }
-
+ dsfadsfdsafaf
+asdfsadfafasdfadf
+asdfsadfafasdfadf dsfadsfdsafaf
+asdfsadfafasdfadf
       &:hover{
         outline: 1px solid #DDDDDD;
         background-color: white;

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -444,7 +444,8 @@ define([
       exec: function (source) {
 
         // Local variables
-        var tile_config, tile_group, tile_type, x, y;
+        var tile_config, tile_group, tile_type, tile_index, x, y,
+            tile, url;
 
         // Check if value selected
         if ($(source).val() === "none") {
@@ -572,9 +573,18 @@ define([
               }
             }
           });
-
+        } else if (tile_config.tile_type === 'field') {
+          // Add field tile
+          url = './@@' + tile_config['tile'] + '?field=' + tile_type;
+          if (typeof tile_config.default_value === 'object') {
+            url += '&' + $.mosaic.encode(tile_config.default_value);
+          }
+          tile = $.mosaic.addTile(
+            tile_type, $.mosaic.getDefaultValue(tile_config), url);
+          if (!tile.isRichText()) {
+            tile.initializeContent();
+          }
         } else {
-
           // Add tile
           $.mosaic.addTile(
             tile_type, $.mosaic.getDefaultValue(tile_config));

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -502,44 +502,44 @@ define([
               authenticator = $value.find('[name="_authenticator"]').val();
               // Open add form in modal when requires user input
               modalFunc = function(html) {
-                $.mosaic.overlay.app = new Modal($('.mosaic-toolbar'), {
+                $.mosaic.modal = new Modal($('.mosaic-toolbar'), {
                   html: html,
                   loadLinksWithinModal: true,
                   buttons: '.formControls > input[type="submit"], .actionButtons > input[type="submit"]'
                 });
-                $.mosaic.overlay.app.$el.off('after-render');
-                $.mosaic.overlay.app.on(
+                $.mosaic.modal.$el.off('after-render');
+                $.mosaic.modal.on(
                   'after-render',
                   function(event) {
                     /* Remove field errors since the user has not actually
                        been able to fill out the form yet */
                     if(initial){
-                      $('.field.error', $.mosaic.overlay.app.$modal)
+                      $('.field.error', $.mosaic.modal.$modal)
                         .removeClass('error');
-                      $('.fieldErrorBox,.portalMessage', $.mosaic.overlay.app.$modal).remove();
+                      $('.fieldErrorBox,.portalMessage', $.mosaic.modal.$modal).remove();
                       initial = false;
                     }
 
                     $('input[name*="cancel"]',
-                      $.mosaic.overlay.app.$modal)
+                      $.mosaic.modal.$modal)
                       .off('click').on('click', function() {
                         // Close overlay
-                        $.mosaic.overlay.app.hide();
-                        $.mosaic.overlay.app = null;
+                        $.mosaic.modal.hide();
+                        $.mosaic.modal = null;
                     });
                   }
                 );
-                $.mosaic.overlay.app.show();
-                $.mosaic.overlay.app.$el.off('formActionSuccess');
-                $.mosaic.overlay.app.on(
+                $.mosaic.modal.show();
+                $.mosaic.modal.$el.off('formActionSuccess');
+                $.mosaic.modal.on(
                   'formActionSuccess',
                   function (event, response, state, xhr) {
                     var tileUrl = xhr.getResponseHeader('X-Tile-Url');
                     if (tileUrl) {
                       $.mosaic.addAppTileHTML(
                         tile_type, response, tileUrl);
-                      $.mosaic.overlay.app.hide();
-                      $.mosaic.overlay.app = null;
+                      $.mosaic.modal.hide();
+                      $.mosaic.modal = null;
                     }
                   }
                 );

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -480,9 +480,9 @@ define([
             return v.toString(16);
           });
 
-          var tileUrl = $.mosaic.options.context_url + '/@@' + tile_type + '/' + uid;
+          var url = $.mosaic.options.context_url + '/@@' + tile_type + '/' + uid;
           var html = '<html><body>' + $.mosaic.getDefaultValue(tile_config) + '</body></html>';
-          $.mosaic.addAppTileHTML(tile_type, html, tileUrl);
+          $.mosaic.addAppTileHTML(tile_type, html, url);
         }else if (tile_config.tile_type === 'app') {
           // Load add form form selected tiletype
           var initial = true;
@@ -561,10 +561,9 @@ define([
                     '_authenticator': authenticator
                   },
                   success: function(value, state, xhr) {
-                    var tileUrl = xhr.getResponseHeader('X-Tile-Url');
-                    if (tileUrl) {
-                      $.mosaic.addAppTileHTML(
-                        tile_type, value, tileUrl);
+                    var url = xhr.getResponseHeader('X-Tile-Url');
+                    if (url) {
+                      $.mosaic.addAppTileHTML(tile_type, value, url);
                     } else {
                       modalFunc(value);
                     }

--- a/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.actions.js
@@ -463,11 +463,29 @@ define([
         $.mosaic.options.panels.trigger("selectedtilechange");
 
         // Get tile config
-        for (x = 0; x < $.mosaic.options.tiles.length; x += 1) {
-          tile_group = $.mosaic.options.tiles[x];
-          for (y = 0; y < tile_group.tiles.length; y += 1) {
-            if (tile_group.tiles[y].name === tile_type) {
-              tile_config = tile_group.tiles[y];
+        if (tile_type.split(':').length === 3) {
+          tile_index = parseInt(tile_type.split(':')[2], 10);
+          tile_group = parseInt(tile_type.split(':')[1], 10);
+          tile_type = tile_type.split(':')[0];
+          try {
+            if ($.mosaic.options.tiles[tile_group]
+                                .tiles[tile_index].name === tile_type) {
+              tile_config = $.mosaic.options.tiles[tile_group]
+                                            .tiles[tile_index];
+            }
+          } catch (e) {}
+        }
+
+        if (!tile_config) {
+          for (x = 0; x < $.mosaic.options.tiles.length; x += 1) {
+            if (typeof tile_config === 'object') { break; }
+            tile_group = $.mosaic.options.tiles[x];
+            for (y = 0; y < tile_group.tiles.length; y += 1) {
+              if (typeof tile_config === 'object') { break; }
+              if (tile_group.tiles[y].name === tile_type) {
+                tile_config = tile_group.tiles[y];
+                break;
+              }
             }
           }
         }
@@ -481,18 +499,23 @@ define([
             return v.toString(16);
           });
 
-          var url = $.mosaic.options.context_url + '/@@' + tile_type + '/' + uid;
+          url = $.mosaic.options.context_url + '/@@' + tile_type + '/' + uid;
           var html = '<html><body>' + $.mosaic.getDefaultValue(tile_config) + '</body></html>';
           $.mosaic.addAppTileHTML(tile_type, html, url);
         }else if (tile_config.tile_type === 'app') {
           // Load add form form selected tiletype
           var initial = true;
+          if (typeof tile_config['default_value'] === 'object') {
+          }
+          url = ($.mosaic.options.context_url + '/@@add-tile?tiletype=' +
+                     tile_type + '&form.button.Create=Create');
+          if (typeof tile_config['default_value'] === 'object') {
+            url += '&' + $.mosaic.encode(tile_config['default_value']);
+          }
           utils.loading.show();
           $.ajax({
             type: "GET",
-            url: $.mosaic.options.context_url +
-              '/@@add-tile?tiletype=' + tile_type +
-              '&form.button.Create=Create',
+            url: url,
             success: function(value, xhr) {
               utils.loading.hide();
               var $value, action_url, authenticator, modalFunc;

--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -758,6 +758,7 @@ define([
    * @param {obj} object
    */
   $.mosaic.encode = function(obj) {
+    if (typeof obj !== 'object') { return ''; }
     var str = [];
     for(var p in obj) {
       if (obj.hasOwnProperty(p)) {
@@ -765,6 +766,24 @@ define([
       }
     }
     return str.join("&");
+  };
+
+  /**
+   * Decode flat JavaScript object from query string
+   *
+   * @param {str} url or querystring
+   */
+  $.mosaic.decode = function(str) {
+    if (typeof str !== 'string') { return {}; }
+    var query = {};
+    var a = (
+      str.indexOf('?') !== -1 ? str.substr(str.indexOf('?') + 1) : str
+    ).split('&');
+    for (var i = 0; i < a.length; i++) {
+        var b = a[i].split('=');
+        query[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || '');
+    }
+    return query;
   };
 
 });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -43,7 +43,7 @@ define([
   'mosaic-url/mosaic.actions'
 ], function ($, logger, _, utils, Modal, Tile, Panel) {
   "use strict";
-  
+
   var log = logger.getLogger('pat-mosaic');
 
   // Define mosaic namespace
@@ -231,7 +231,7 @@ define([
     $.mosaic.initActions();
 
     // Initialize options
-    $.mosaic.options = options.data;  // XXX: Required options not documented 
+    $.mosaic.options = options.data;  // XXX: Required options not documented
     $.mosaic.tileHeadElements = [];
     $.mosaic.hasContentLayout = true;
 
@@ -249,11 +249,11 @@ define([
     if (content) {
       $content = $.mosaic.getDomTreeFromHtml(content);
       if ($content.attr('id') !== "no-layout") {
-        
+
         // Remove unplaced saved helper tiles saved because of a fixed bug
         $content.find('.mosaic-helper-tile-new')
                 .parents('.mosaic-grid-row').remove();
-        
+
         $('body').addClass('mosaic-layout-customized');
         $.mosaic.hasContentLayout = false;
         $.mosaic._init($content);

--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -300,7 +300,7 @@ define([
       url: $.mosaic.options.layout,
       cache: false
     }).done(function (layoutHtml) {
-      $.mosaic.__initPanels($content, $(layoutHtml), callback);
+      $.mosaic.__initPanels($content, $('<div>' + layoutHtml + '</div>'), callback);
     }).fail(function (xhr, type, status) {
       $.mosaic.__initPanels($content, $(), callback);
     }).always(function () {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -752,4 +752,19 @@ define([
     $(window).queue(queueName, callback);
   };
 
+  /**
+   * Encode flat JavaScript object into query string
+   *
+   * @param {obj} object
+   */
+  $.mosaic.encode = function(obj) {
+    var str = [];
+    for(var p in obj) {
+      if (obj.hasOwnProperty(p)) {
+        str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+      }
+    }
+    return str.join("&");
+  };
+
 });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.core.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.core.js
@@ -356,6 +356,8 @@ define([
   $.mosaic._init = function (content) {
     // Init layout
     $.mosaic._initPanels(content, function() {
+      // Init overlay
+      $('.mosaic-original-content', $.mosaic.document).mosaicOverlay();
 
       // Init toolbar (expects panels been initialized)
       $.mosaic.options.toolbar = $(document.createElement('div'))
@@ -363,7 +365,6 @@ define([
 
       // Signal initial load completed
       $.mosaic.initialized();
-
     });
   };
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -1146,7 +1146,7 @@ define([
 
     var $tile = $(".mosaic-new-tile", $.mosaic.document);
     $tile.removeClass("mosaic-new-tile");
-    
+
     // Break on cancelled drop
     if ($tile.length === 0) {
       return null;
@@ -1696,7 +1696,7 @@ define([
           .append($($.mosaic.document.createElement("div"))
             .addClass("mosaic-grid-cell mosaic-width-half mosaic-position-leftmost")));
     }
-    
+
     // Add helper
     $($.mosaic.options.panels.find('.mosaic-grid-row:not(.mosaic-empty-row) .mosaic-grid-cell').get(0)).append(
       $($.mosaic.document.createElement("div"))

--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -104,6 +104,9 @@ define([
       // Check if esc
       if (e.keyCode === 27) {
 
+        // Close overlay if open
+        $.mosaic.overlay.close();
+
         // Check if dragging
         var original_tile = $(".mosaic-original-tile", $.mosaic.document);
         if (original_tile.length > 0) {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.layout.js
@@ -139,9 +139,9 @@ define([
         });
 
         // Hide overlay
-        if ($.mosaic.overlay.app) {
-          $.mosaic.overlay.app.hide();
-          // $.mosaic.overlay.$el.trigger('destroy.modal.patterns');;
+        if ($.mosaic.modal) {
+          $.mosaic.modal.hide();
+          // $.mosaic.modal.$el.trigger('destroy.modal.patterns');;
         }
       }
     };
@@ -1581,9 +1581,9 @@ define([
   $.mosaic.addAppTile = function (type, url /*, id */) {
 
     // Close overlay
-    if ($.mosaic.overlay.app) {
-      $.mosaic.overlay.app.hide();
-      // $.mosaic.overlay.trigger('destroy.modal.patterns');
+    if ($.mosaic.modal) {
+      $.mosaic.modal.hide();
+      // $.mosaic.modal.trigger('destroy.modal.patterns');
     }
 
     // Get value
@@ -1633,7 +1633,10 @@ define([
   $.mosaic.editAppTile = function (url) {
 
     // Close overlay
-    $.mosaic.overlay.close();
+    if ($.mosaic.modal) {
+      $.mosaic.modal.hide();
+      // $.mosaic.modal.trigger('destroy.modal.patterns');
+    }
 
     // Focus on current window
     window.parent.focus();

--- a/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
@@ -68,7 +68,7 @@ define([
       // Init overlay
       var $modalStructure = $(
         '<div class="plone-modal-wrapper mosaic-overlay">' +
-          '<div class="mosaic-modal fade in" style="position: absolute; padding: 20px;">' +
+          '<div class="mosaic-modal" style="position: absolute; padding: 20px;">' +
             '<div class="plone-modal-dialog">' +
               '<div class="plone-modal-content">' +
                 '<div class="plone-modal-header"><a class="plone-modal-close">×</a></div>' +
@@ -196,6 +196,12 @@ define([
           .removeClass('mosaic-hidden');
       }
 
+      // Hide layout fields
+      form.find('#formfield-form-widgets-ILayoutAware-pageSiteLayout')
+        .addClass('mosaic-hidden');
+      form.find('#formfield-form-widgets-ILayoutAware-sectionSiteLayout')
+        .addClass('mosaic-hidden');
+
       // Hide field which are on the wysiwyg area
       for (x = 0; x < $.mosaic.options.tiles.length; x += 1) {
         if ($.mosaic.options.tiles[x].name === 'fields') {
@@ -214,9 +220,8 @@ define([
 
       // Hide tab if fieldset has no visible items
       form.find("fieldset").each(function () {
-        if ($(this).children("div:not(.mosaic-hidden)").length === 0) {
-          $('a[href=#fieldsetlegend-' +
-            $(this).attr('id').split('-')[1] + ']')
+        if ($(this).children("div:not(legend, .mosaic-hidden)").length === 0) {
+          $('a[href=#autotoc-item-autotoc-' + ($(this).index() - 1) + ']')
             .addClass('mosaic-hidden');
         }
       });
@@ -266,6 +271,7 @@ define([
     // Hide overlay
     $('.mosaic-overlay').hide().removeClass('active');
     $('.mosaic-overlay-blocker').hide();
+    $('.mosaic-overlay .mosaic-modal').removeClass('plone-modal');
     $('body').removeClass('plone-modal-open');
   };
 });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
@@ -130,6 +130,8 @@ define([
 
     // Expand the overlay
     $('.mosaic-overlay').show().addClass('active');
+    $('.mosaic-overlay .mosaic-modal').addClass('plone-modal');
+    $('.mosaic-overlay .mosaic-modal').show();
     $('.mosaic-overlay-blocker').show();
     $('body').addClass('plone-modal-open');
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.overlay.js
@@ -122,7 +122,9 @@ define([
    * @param {String} mode Mode of the overlay
    * @param {Object} tile_config Configuration of the tile
    */
-  $.mosaic.overlay.open = function (mode, tile_config) {
+  $.mosaic.overlay.open = function (mode, tile_config, callback) {
+    // Wire callback
+    $.mosaic.overlay.callback = callback;
 
     // Local variables
     var form, formtabs, tile_group, x, visible_tabs,
@@ -273,5 +275,12 @@ define([
     $('.mosaic-overlay-blocker').hide();
     $('.mosaic-overlay .mosaic-modal').removeClass('plone-modal');
     $('body').removeClass('plone-modal-open');
+
+    // Execute callback
+    if (typeof $.mosaic.overlay.callback) {
+      var callback = $.mosaic.overlay.callback;
+      delete $.mosaic.overlay['callback'];
+      callback();
+    }
   };
 });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
@@ -5,8 +5,9 @@ immed: true, strict: true, maxlen: 150, maxerr: 9999, quotmark: false */
 define([
   'jquery',
   'pat-logger',
+  'pat-registry',
   'underscore'
-], function($, logger, _) {
+], function($, logger, Registry, _) {
   'use strict';
 
   var log = logger.getLogger('pat-mosaic');
@@ -16,7 +17,7 @@ define([
     this.$el = $(el);
   };
 
-  Panel.prototype.initialize = function($content){
+  Panel.prototype.initialize = function($content) {
     // Local variables
     var panel_id = this.$el.attr("data-panel"), panel_attr_id,
         target = $("[data-panel=" + panel_id + "]", $.mosaic.document),
@@ -50,6 +51,7 @@ define([
             .removeAttr('id')
             .addClass('mosaic-original-content')
             .hide();
+        Registry.scan(target.prev());
       } else {
         // re-initializing, so we just have to replace existing
         target.replaceWith($(document.createElement("div"))
@@ -59,6 +61,7 @@ define([
             .attr('data-panel', 'content')
             .attr('data-max-columns', max_columns)
             .html($content.find("[data-panel=" + panel_id + "]").html()));
+        Registry.scan(target);
       }
     } else {
       target.attr("class",
@@ -66,6 +69,7 @@ define([
       target.addClass('mosaic-panel');
       target.html($content.find("[data-panel=" +
           panel_id + "]").html());
+      Registry.scan(target);
     }
   };
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.panel.js
@@ -18,9 +18,12 @@ define([
 
   Panel.prototype.initialize = function($content){
     // Local variables
-    var panel_id = this.$el.data("panel"), panel_attr_id,
+    var panel_id = this.$el.attr("data-panel"), panel_attr_id,
         target = $("[data-panel=" + panel_id + "]", $.mosaic.document),
-        max_columns = (this.$el.data('max-columns') || 4);
+        max_columns = parseInt(this.$el.attr('data-max-columns'), 10) || 4;
+
+    // Ensure max columns on new panels
+    target.attr('data-max-columns', max_columns);
 
     // Implicitly initialize required panels with id matching element
     if (panel_id === 'content' && target.length === 0) {
@@ -34,7 +37,7 @@ define([
     // this panel
     if (panel_id === 'content') {
       panel_attr_id = target.attr('id');
-      if($('.mosaic-original-content', $.mosaic.document).size() === 0){
+      if ($('.mosaic-original-content', $.mosaic.document).length === 0) {
         target.before($(document.createElement("div"))
             .attr("id", panel_attr_id)
             .attr("class", target.attr("class"))
@@ -45,8 +48,9 @@ define([
         target
             .removeAttr('data-panel')
             .removeAttr('id')
-            .addClass('mosaic-original-content');
-      }else{
+            .addClass('mosaic-original-content')
+            .hide();
+      } else {
         // re-initializing, so we just have to replace existing
         target.replaceWith($(document.createElement("div"))
             .attr("id", panel_attr_id)
@@ -62,23 +66,6 @@ define([
       target.addClass('mosaic-panel');
       target.html($content.find("[data-panel=" +
           panel_id + "]").html());
-    }
-  };
-
-  Panel.prototype.prefill = function(){
-    if (!this.$el.hasClass('mosaic-panel')) {
-      log.info($(this));
-      $(this).addClass('mosaic-panel');
-      $(this).children().wrap($(
-        '<div class="mosaic-grid-row">' +
-          '<div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">' +
-            '<div class="movable removable mosaic-tile mosaic-text-tile">' +
-              '<div class="mosaic-tile-content">' +
-              '</div>' +
-            '</div>' +
-          '</div>' +
-        '</div>'
-      ));
     }
   };
 

--- a/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
@@ -32,7 +32,7 @@ require([
 ], function($, Base) {
   'use strict';
 
-  var Layout = Base.extend({
+  return Base.extend({
     name: 'layout',
     trigger: '.pat-layout',
     parser: 'mockup',
@@ -45,6 +45,7 @@ require([
 
       // Remove Plone Toolbar and its body classes
       $('#edit-bar, .pat-toolbar').remove();
+      $(window).off('resize');
       $body = $('body');
       $body.attr('class').split(' ').forEach(function (className) {
         if (className.indexOf('plone-toolbar') !== -1) {
@@ -58,6 +59,4 @@ require([
       $.mosaic.init({'data': self.options.data});
     }
   });
-
-  return Layout;
 });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
@@ -20,7 +20,6 @@
  *    with this program; if not, write to the Free Software Foundation, Inc.,
  *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-window.DEBUG = true;
 require([
   'jquery',
   'mockup-patterns-base',

--- a/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.pattern.js
@@ -39,9 +39,22 @@ require([
     defaults: {
       attribute: 'class'
     },
-    init: function() {
-      var self = this;
+    init: function () {
+      var self = this, $body;
       self.options.data.$el = self.$el;
+
+      // Remove Plone Toolbar and its body classes
+      $('#edit-bar, .pat-toolbar').remove();
+      $body = $('body');
+      $body.attr('class').split(' ').forEach(function (className) {
+        if (className.indexOf('plone-toolbar') !== -1) {
+          $body.removeClass(className);
+        }
+      });
+      // Note: If Plone Toolbar is not completely removed, its body classes
+      // will reappear immediately.
+
+      // Init Mosaic
       $.mosaic.init({'data': self.options.data});
     }
   });

--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -641,28 +641,28 @@ define([
 
 
         // Open overlay
-        $.mosaic.overlay.app = new Modal($('.mosaic-toolbar'), {
+        $.mosaic.modal = new Modal($('.mosaic-toolbar'), {
           ajaxUrl: tile_url,
           loadLinksWithinModal: true,
           buttons: '.formControls > input[type="submit"], .actionButtons > input[type="submit"]'
         });
-        $.mosaic.overlay.app.$el.off('after-render');
-        $.mosaic.overlay.app.on('after-render', function(event) {
+        $.mosaic.modal.$el.off('after-render');
+        $.mosaic.modal.on('after-render', function(event) {
           $('input[name*="cancel"]',
-            $.mosaic.overlay.app.$modal)
+            $.mosaic.modal.$modal)
             .off('click').on('click', function() {
               // Close overlay
-              $.mosaic.overlay.app.hide();
-              $.mosaic.overlay.app = null;
+              $.mosaic.modal.hide();
+              $.mosaic.modal = null;
           });
           if($.mosaic.hasContentLayout){
             // not a custom layout, make sure the form knows
-            $('form', $.mosaic.overlay.app.$modal).append($('<input type="hidden" name="X-Tile-Persistent" value="yes" />'));
+            $('form', $.mosaic.modal.$modal).append($('<input type="hidden" name="X-Tile-Persistent" value="yes" />'));
           }
         });
-        $.mosaic.overlay.app.show();
-        $.mosaic.overlay.app.$el.off('formActionSuccess');
-        $.mosaic.overlay.app.on('formActionSuccess', function (event, response, state, xhr, form) {
+        $.mosaic.modal.show();
+        $.mosaic.modal.$el.off('formActionSuccess');
+        $.mosaic.modal.on('formActionSuccess', function (event, response, state, xhr, form) {
           var tileUrl = xhr.getResponseHeader('X-Tile-Url'),
             value = $.mosaic.getDomTreeFromHtml(response);
           if (tileUrl) {
@@ -675,8 +675,8 @@ define([
             that.fillContent(tileHtml, tileUrl);
 
             // Close overlay
-            $.mosaic.overlay.app.hide();
-            $.mosaic.overlay.app = null;
+            $.mosaic.modal.hide();
+            $.mosaic.modal = null;
           }
         });
       } else {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -341,6 +341,19 @@ define([
       }
     }
 
+    if(!tile_config && tiletype === 'static') {
+      tile_config = {
+        tile_type: 'text',
+        name: tiletype,
+        label: 'Static',
+        read_only: true,
+        favorite: false,
+        settings: false,
+        weight: 0,
+        rich_text: false
+      };
+    }
+
     if(!tile_config){
       // dive out of here, something went wrong finding tile config
       if(_missing_tile_configs.indexOf(tiletype) === -1){

--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -410,7 +410,12 @@ define([
         body += '          <div class="mosaic-tile-content">\n';
 
         // Calc url
-        var tile_url = './@@plone.app.standardtiles.field?field=' + tiletype;
+        var tile_url = './@@' + tile_config['tile'] + '?field=' + tiletype;
+
+        // Ability to fixed configuration from configured tile default_value
+        if (typeof tile_config.default_value === 'object') {
+          tile_url += '&' + $.mosaic.encode(tile_config.default_value);
+        }
 
         // ability to provide a few additional settings for field tiles
         // can be useful in formatting field tiles in python

--- a/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.tile.js
@@ -786,7 +786,8 @@ define([
         $.ajax({
           url: dataUrl,
           method: 'POST',
-          success: function (value) {
+          success: function (value, status, xhr) {
+            dataUrl = xhr.getResponseHeader('X-Tile-Url');
             self.$el.removeClass('mosaic-tile-loading');
 
             // Parse

--- a/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
@@ -511,7 +511,6 @@ define([
       // Trigger inline validation draft auto save
       var lastChange = (new Date()).getTime();
       $(this).on('selectedtilechange', function () {
-        if ($.mosaic.overlay.app) { return; }
         if ($.mosaic.saving) { return; }  // skip when saving
         if ($.mosaic.modal) { return; }  // skip when there's modal
         if ((new Date()).getTime() - lastChange > 6000) {

--- a/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
+++ b/src/plone/app/mosaic/browser/static/js/mosaic.toolbar.js
@@ -235,7 +235,7 @@ define([
           var tile = action_group.tiles[y];
           elm_action_group.append($(document.createElement("option"))
             .addClass("mosaic-option mosaic-option-" + normalizeClass(tile.name))
-            .attr("value", tile.name)
+            .attr("value", tile.name + ':' + x + ':' + y)  // optimize
             .html(tile.label)
           );
         }
@@ -470,7 +470,7 @@ define([
           .children(".mosaic-option-group-fields")
           .children().each(function () {
           if ($.mosaic.options.panels
-            .find(".mosaic-" + $(this).attr("value") + "-tile")
+            .find(".mosaic-" + $(this).attr("value").split(':')[0] + "-tile")
             .length === 0) {
             $(this).show().removeAttr("disabled");
           } else {

--- a/src/plone/app/mosaic/profiles/default/registry.xml
+++ b/src/plone/app/mosaic/profiles/default/registry.xml
@@ -719,7 +719,8 @@
        is fixed to support freely placed TOCs -->
   <!--
   <records prefix="plone.app.mosaic.app_tiles.plone_app_standardtiles_tableofcontents"
-           interface="plone.app.mosaic.interfaces.ITile">
+           interface="plone.app.mosaic.interfaces.ITile"
+           delete="true" />
     <value key="name">plone.app.standardtiles.tableofcontents</value>
     <value key="label">Table of contents</value>
     <value key="category">structure</value>

--- a/src/plone/app/mosaic/registry.py
+++ b/src/plone/app/mosaic/registry.py
@@ -217,6 +217,11 @@ class MosaicRegistry(object):
         for key, tile in tiles.items():
             if 'category' not in tile:
                 continue
+            try:
+                tile['default_value'] = json.loads(tile.get('default_value'))
+            except (TypeError, ValueError):
+                # default_value can also be None or string
+                pass
             index = getCategoryIndex(config['tiles'], tile['category'])
             if index is not None:
                 config['tiles'][index]['tiles'].append(tile)

--- a/src/plone/app/mosaic/utils.py
+++ b/src/plone/app/mosaic/utils.py
@@ -103,6 +103,7 @@ def extractFieldInformation(schema, context, request, prefix):
                     'title': schema[name].title,
                     'widget': _getWidgetName(schema[name], widgets, request),
                     'readonly': name in read_only,
+                    'tile': 'plone.app.standardtiles.field'
                 }
 
 


### PR DESCRIPTION
This will need some documentation before merge.

I've branched 2.0rc7 into 2.0.x branch with intent to release that as 2.0 after pretty soon if more blocking issues emerges.

The current master is for 2.1 with some site layout features I've been using from the beginning of the year:

* static panels with editable tiles: site layouts could define static panels, whose tiles are editable in Mosaic editor; this allows layouts with both static and fully customizable areas

* support to read site layout from content layout; the current site layout dropdowns on "Layout" are not ideal; when site layout can be read from content layout, we could reuse the current content layout selection also for site layout selection (by letting content layout also define its depending site layout); missing part is that editor does not live-update changed site layout yet

These are more WIP and I still might retract these back to my datakurre-custom branch:

* custom field tiles; ability to define custom field tiles for custom content types' fields

* live backend-rendered preview of field tiles (depends on https://github.com/plone/mockup/pull/775, https://github.com/plone/plone.app.tiles/pull/23)