### PR TITLE
Transform: safe context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0rc9 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Transform: Acquire a safe context or the portal object.
+  In cases of a 404 page, the context is a browser view.
+  [thet]
 
 
 2.0rc8 (2017-09-05)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'plone.api',
         'plone.subrequest>=1.8',
         'plone.tiles>=1.8.3',
         'plone.app.blocks>=4.1.0',


### PR DESCRIPTION
Acquire a safe context or the portal object.
In cases of a 404 page, the context is a browser view.

This fixes two cases - when 404 pages are rendered the context is a BrowserView and another which I got via sentry, but cannot reproduce:

```
AttributeError: 'ImageScaling' object has no attribute 'portal_type'
  File "plone/buildout/eggs/plone.transformchain-1.2.1-py2.7.egg/plone/transformchain/transformer.py", line 49, in __call__
    newResult = handler.transformIterable(result, encoding)
  File "plone/buildout/eggs/plone.app.mosaic-2.0rc5-py2.7.egg/plone/app/mosaic/transform.py", line 52, in transformIterable
    return self.transform(result, encoding)
  File "plone/buildout/eggs/plone.app.mosaic-2.0rc5-py2.7.egg/plone/app/mosaic/transform.py", line 127, in transform
    n for n in layout.bodyClass(None, self.published).split()
  File "plone/buildout/src-aaf/bda.aaf.site/src/bda/aaf/site/content.py", line 354, in bodyClass
    body_class = super(AAFLayoutPolicy, self).bodyClass(template, view)
  File "plone/buildout/eggs/plone.app.layout-2.7.4-py2.7.egg/plone/app/layout/globals/layout.py", line 244, in bodyClass
    portal_type = normalizer.normalize(self.context.portal_type)
```
This happened when accessing a image scale - but when I do it directly all is fine:

https://somedomain.com/kalender/archiv/architektur-hoeren-sehen/plus-energie-haeuser/plus-energie-buerohaus-am-getreidemarkt/@@images/d2edfbb6-ae32-400d-9bec-84c084ed7c05.jpeg

I have the mosaic setting, which - IIRC - makes all responses use site layouts.
```
  <record name="plone.defaultSiteLayout">
    <value>++sitelayout++aafsite/aaf.html</value>
  </record>
```
