### PR TITLE
transform: if no context is found, return the portal object

### DIFF
--- a/src/plone/app/mosaic/transform.py
+++ b/src/plone/app/mosaic/transform.py
@@ -28,7 +28,7 @@ def getContext(context):
     portal object.
     """
     context = aq_parent(aq_base(context))
-    if IBrowserView.providedBy(context):
+    if not context or IBrowserView.providedBy(context):
         return getSite()
     return context
 


### PR DESCRIPTION
@asko tnx for merging https://github.com/plone/plone.app.mosaic/pull/386

I missed to handle empty contexts like it was done before. This PR fixes that.