### PR TITLE
Image in Existingcontent Tiles scales width only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 Bug fixes:
 
+- Image in "Existing-Content" Tile scaled width only, height was kept and aspect-ratio broke.
+  Fixes https://github.com/plone/plone.app.standardtiles/issues/83.
+  [jensens]
+
 - Hide dependencies - like blocks and tiles - of Mosaic from appearing at Plone site setup.
   This reduces confusion and removes clutter from the setup screen.
   [jensens]
@@ -14,7 +18,7 @@ Bug fixes:
   In cases of a 404 page, the context is a browser view.
   [thet]
 
-- Imports are Python3 compatible 
+- Imports are Python3 compatible
   [b4oshany]
 
 

--- a/src/plone/app/mosaic/browser/static/css/mosaic.styles.less
+++ b/src/plone/app/mosaic/browser/static/css/mosaic.styles.less
@@ -1,6 +1,7 @@
 /* Images will never be bigger then a tile */
 .mosaic-tile img {
   max-width: 100%;
+  height: auto;
 }
 
 .mosaic-tile-align-center {

--- a/src/plone/app/mosaic/browser/static/mosaic-styles.css
+++ b/src/plone/app/mosaic/browser/static/mosaic-styles.css
@@ -1,6 +1,7 @@
 /* Images will never be bigger then a tile */
 .mosaic-tile img {
   max-width: 100%;
+  height: auto;
 }
 .mosaic-tile-align-center {
   text-align: center;


### PR DESCRIPTION
Height was kept and aspect-ratio broke.

Fixes plone/plone.app.standardtiles#83.