### PR TITLE
Revert "Change IRichtext plone.app.standardtiles behavior registration"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,6 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-Breaking change:
-
-- Change IRichtext field in provide document content layout and newsitem content layout from IRichText-text to IRichTextBehavior-text.
-  Needed because of a breaking change in plone.app.contenttypes 1.4.12 which is/will be included in Plone 5.1.4 and later.
-  If you have saved user/global content layouts in your site or in custom add'ons on filesystem, please change these layouts as well when you upgrade to Plone 5.1.4 or later.
-  You can find contentlayouts in you site in the ZMI under portal_resources in the contentlayout folder.
-  [fredvd]
-
 - when deleting custom layout within ``manage custom layouts`` do not show currently selected layout in ``replacement layout`` listing.
   [petschki]
 

--- a/src/plone/app/mosaic/forms.py
+++ b/src/plone/app/mosaic/forms.py
@@ -10,7 +10,6 @@ class MosaicDefaultAddForm(add.DefaultAddForm):
 
     hidden_fields = [
         'IRichText.text',
-        'IRichTextBehavior.text',
         'IVersionable.changeNote'
     ]
 

--- a/src/plone/app/mosaic/layouts/content/document.html
+++ b/src/plone/app/mosaic/layouts/content/document.html
@@ -1,36 +1,34 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" data-layout="./@@page-site-layout">
-
 <body>
-  <div data-panel="content">
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IDublinCore-title-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-title"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IDublinCore-description-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-description"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IRichText-text-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=IRichTextBehavior-text"></div>
-          </div>
+<div data-panel="content">
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IDublinCore-title-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-title"></div>
         </div>
       </div>
     </div>
   </div>
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IDublinCore-description-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-description"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IRichText-text-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IRichText-text"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
-
 </html>

--- a/src/plone/app/mosaic/layouts/content/news_item.html
+++ b/src/plone/app/mosaic/layouts/content/news_item.html
@@ -1,36 +1,34 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" data-layout="./@@page-site-layout">
-
 <body>
-  <div data-panel="content">
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IDublinCore-title-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-title"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IDublinCore-description-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-description"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="mosaic-grid-row">
-      <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
-        <div class="movable removable mosaic-tile mosaic-IRichText-text-tile">
-          <div class="mosaic-tile-content">
-            <div data-tile="./@@plone.app.standardtiles.field?field=field=IRichTextBehavior-text"></div>
-          </div>
+<div data-panel="content">
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IDublinCore-title-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-title"></div>
         </div>
       </div>
     </div>
   </div>
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IDublinCore-description-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IDublinCore-description"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="mosaic-grid-row">
+    <div class="mosaic-grid-cell mosaic-width-full mosaic-position-leftmost">
+      <div class="movable removable mosaic-tile mosaic-IRichText-text-tile">
+        <div class="mosaic-tile-content">
+          <div data-tile="./@@plone.app.standardtiles.field?field=IRichText-text"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
-
 </html>


### PR DESCRIPTION
This change was moved from plone.app.contenttypes 1.4.X /Plone 5.1
to plone.app.contenttypes 2.X / Plone 5.2 because it breaks too much.

We'll need to fix this in mosaic at some point, probably Plone 5.2

This reverts commit e2189980b99442fab4e2d9ce1224754f2cebc6c4.