### PR TITLE
Add ``bootstrapPath`` less variable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.2.4 (unreleased)
 ------------------
 
+- Add ``bootstrapPath`` less variable.
+  Now the bundle can be built with ``plone-compile-resources``.
+  Contains an upgrade step.
+  [thet]
+
 - Fix Flake8 errors
   [jugmac00]
 

--- a/src/plone/app/mosaic/profiles/default/metadata.xml
+++ b/src/plone/app/mosaic/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>5028</version>
+  <version>5029</version>
   <dependencies>
     <dependency>profile-plone.app.contenttypes:default</dependency>
     <dependency>profile-plone.app.drafts:default</dependency>

--- a/src/plone/app/mosaic/profiles/default/registry.xml
+++ b/src/plone/app/mosaic/profiles/default/registry.xml
@@ -1075,4 +1075,10 @@
     </value>
   </records>
 
+  <record name="plone.lessvariables">
+    <value purge="False">
+      <element key="bootstrapPath">\"{site_url}/++plone++static/components/bootstrap/\"</element>
+    </value>
+  </record>
+
 </registry>

--- a/src/plone/app/mosaic/profiles/upgrades/to_5029/registry.xml
+++ b/src/plone/app/mosaic/profiles/upgrades/to_5029/registry.xml
@@ -1,0 +1,9 @@
+<registry>
+
+  <record name="plone.lessvariables">
+    <value purge="False">
+      <element key="bootstrapPath">\"{site_url}/++plone++static/components/bootstrap/\"</element>
+    </value>
+  </record>
+
+</registry>

--- a/src/plone/app/mosaic/upgrades.zcml
+++ b/src/plone/app/mosaic/upgrades.zcml
@@ -408,4 +408,21 @@
       run_deps="false"
       />
 
+  <genericsetup:registerProfile
+      name="to_5029"
+      title="Upgrade profile to 5029"
+      description=""
+      directory="profiles/upgrades/to_5029"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:upgradeDepends
+      profile="plone.app.mosaic:default"
+      source="5028"
+      destination="5029"
+      title="Add bootstrapPath less variable"
+      import_profile="plone.app.mosaic:to_5029"
+      />
+
 </configure>


### PR DESCRIPTION
Now the bundle can be built with ``plone-compile-resources``.
Contains an upgrade step.