### PR TITLE
Fixed old upgrade step that tried to set plone.lessvariables.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fixed old upgrade step that tried to set plone.lessvariables.
+  Ignore this on Plone 6, because it fails.
+  [maurits]
 
 
 3.0.0a2 (2022-07-07)

--- a/mx.ini
+++ b/mx.ini
@@ -23,6 +23,9 @@ version-overrides =
     robotframework-seleniumlibrary==6.0.0
     robotsuite==2.3.1
     selenium==4.2.0
+    # products-cmfplone 6.0.0b1.dev0 depends on webresource>=1.1
+    webresource==1.1
+
 
 default-install-mode = direct
 

--- a/src/plone/app/mosaic/profiles/upgrades/to_5029/registry.xml
+++ b/src/plone/app/mosaic/profiles/upgrades/to_5029/registry.xml
@@ -1,6 +1,7 @@
 <registry>
 
-  <record name="plone.lessvariables">
+  <record name="plone.lessvariables"
+      condition="not-have plone-60">
     <value purge="False">
       <element key="bootstrapPath">\"{site_url}/++plone++static/components/bootstrap/\"</element>
     </value>


### PR DESCRIPTION
Ignore this on Plone 6, because it fails:

```
ValueError: http://localhost:8080/nl/upgrade_products
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 167, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 376, in publish_module
  Module ZPublisher.WSGIPublisher, line 271, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 521, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 290, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 218, in doStep
  Module Products.GenericSetup.tool, line 399, in runAllImportStepsFromProfile
   - __traceback_info__: profile-plone.app.mosaic:to_5029
  Module Products.GenericSetup.tool, line 1511, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: plone.app.registry
  Module plone.app.registry.exportimport.handler, line 80, in importRegistry
   - __traceback_info__: registry.xml
  Module plone.app.registry.exportimport.handler, line 125, in importDocument
  Module plone.app.registry.exportimport.handler, line 264, in importRecord
   - __traceback_info__: record name: plone.lessvariables
ValueError: Cannot find a field for the record plone.lessvariables. Add a <field /> element or reference an interface and field name.
```