### PR TITLE
Remove barceloneta as dependency 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove ``plonetheme.barceloneta`` dependency. (Not needed)
+  [toalba]
 
 
 3.1.0 (2023-03-06)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "plone.app.drafts",
         "plone.app.standardtiles",
         "plone.staticresources >= 2.1.0",
-        "plonetheme.barceloneta >= 3.1.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
With [plone.app.theming/pull/216](https://github.com/plone/plone.app.theming/pull/216) mosaic is compatible with all sorts of plonethemes. Barceloneta is not needed in mosaic.