### PR TITLE
portal_properties have been removed

### DIFF
--- a/news/633.bugfix
+++ b/news/633.bugfix
@@ -1,0 +1,1 @@
+Remove portal_properties from Plone < 6. [gogobd]

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -44,7 +44,6 @@ TEMPLATE = """\
         dummy python:plone_layout.mark_view(view);
         portal_url portal_state/portal_url;
         checkPermission nocall: context/portal_membership/checkPermission;
-        site_properties nocall: context/portal_properties/site_properties;
         ajax_include_head request/ajax_include_head | nothing;
         ajax_load request/ajax_load | python: False;
         toolbar_class python:request.cookies.get('plone-toolbar', 'plone-toolbar-left pat-toolbar');


### PR DESCRIPTION
We got an error, because portal_properties has been removed (for Plone 6.1) - so we had to "softly ignore" it when it's missing.