### PR TITLE
Define the compatible node version.

### DIFF
--- a/news/529.internal.rst
+++ b/news/529.internal.rst
@@ -1,0 +1,2 @@
+Define the compatible node version.
+[thet]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
         "css-compile": "sass --load-path=node_modules --style expanded --source-map --embed-sources --no-error-css resources/scss/mosaic.scss:src/plone/app/mosaic/browser/static/mosaic.css",
         "css-minify": "cleancss -O1 --format breakWith=lf --with-rebase --source-map --source-map-inline-sources --output src/plone/app/mosaic/browser/static/mosaic.min.css src/plone/app/mosaic/browser/static/mosaic.css"
     },
+    "engines": {
+        "node": ">=22"
+    },
     "browserslist": [
         "defaults"
     ],


### PR DESCRIPTION
This defines the "engines" field of package.json which is a standard field as specified here: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines

plone.app.mosaic probably would work with lower versions of Node also - e.g. Node version 18, but "22" is the current LTS version.

Ref: https://github.com/plone/mockup/pull/1465
Obsoletes: https://github.com/plone/plone.app.mosaic/pull/529