### PR TITLE
Drop use of pkg_resources in code.

### DIFF
--- a/news/4126.internal.rst
+++ b/news/4126.internal.rst
@@ -1,0 +1,1 @@
+Drop use of ``pkg_resources`` in code.  [maurits]

--- a/src/plone/app/mosaic/browser/main_template.py
+++ b/src/plone/app/mosaic/browser/main_template.py
@@ -1,4 +1,5 @@
 from hashlib import md5
+from importlib.resources import files
 from lxml import etree
 from lxml import html
 from plone.app.blocks.interfaces import IBlocksTransformEnabled
@@ -21,7 +22,6 @@ from zope.interface import implementer
 
 import logging
 import os
-import pkg_resources
 import re
 
 
@@ -205,13 +205,13 @@ class Macro(list):
 
 def resolve_ajax_main_template():
     main_template = os.path.join("browser", "templates", "ajax_main_template.pt")
-    filename = pkg_resources.resource_filename("Products.CMFPlone", main_template)
+    filename = files("Products.CMFPlone") / main_template
     return ViewPageTemplateFile(filename)
 
 
 def resolve_main_template():
     main_template = os.path.join("browser", "templates", "main_template.pt")
-    filename = pkg_resources.resource_filename("Products.CMFPlone", main_template)
+    filename = files("Products.CMFPlone") / main_template
     return ViewPageTemplateFile(filename)
 
 


### PR DESCRIPTION
I don't actually know how to properly try this out.  I disabled the zcml condition, so this `main_template.py` should be used, but a breakpoint in the `__call__` method never gets called.

But I can call the function, and there it works:

```
>>> from plone.app.mosaic.browser.main_template import resolve_main_template
>>> x = resolve_main_template()
>>> x
<Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x10b69ea40>
>>> x.pt_source_file()
'/Users/maurits/shared-eggs/v5/cp310/Products.CMFPlone-6.1.2-py3.10-macosx-15.6-arm64.egg/Products/CMFPlone/browser/templates/main_template.pt'
```
